### PR TITLE
[ Develop ] 유저 스토어 찜 등록 기능

### DIFF
--- a/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/store/Store.java
+++ b/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/store/Store.java
@@ -1,0 +1,16 @@
+package com.whatsub.honeybread.core.domain.store;
+
+
+import com.whatsub.honeybread.core.domain.base.BaseEntity;
+import lombok.*;
+
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+@Getter
+@EqualsAndHashCode(callSuper = true)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "stores")
+public class Store extends BaseEntity {
+}

--- a/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/store/StoreRepository.java
+++ b/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/store/StoreRepository.java
@@ -3,5 +3,4 @@ package com.whatsub.honeybread.core.domain.store;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StoreRepository extends JpaRepository<Store, Long> {
-    boolean existsById(Long id);
 }

--- a/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/store/StoreRepository.java
+++ b/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/store/StoreRepository.java
@@ -1,0 +1,7 @@
+package com.whatsub.honeybread.core.domain.store;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StoreRepository extends JpaRepository<Store, Long> {
+    boolean existsById(Long id);
+}

--- a/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/userstorefavorite/UserStoreFavorite.java
+++ b/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/userstorefavorite/UserStoreFavorite.java
@@ -1,0 +1,22 @@
+package com.whatsub.honeybread.core.domain.userstorefavorite;
+
+
+import com.whatsub.honeybread.core.domain.base.BaseEntity;
+import lombok.*;
+
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+@Getter
+@EqualsAndHashCode(callSuper = true)
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "user_store_favorites")
+public class UserStoreFavorite extends BaseEntity {
+
+    private Long userId;
+
+    private Long storeId;
+
+}

--- a/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/userstorefavorite/UserStoreFavoriteRepository.java
+++ b/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/userstorefavorite/UserStoreFavoriteRepository.java
@@ -1,0 +1,7 @@
+package com.whatsub.honeybread.core.domain.userstorefavorite;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserStoreFavoriteRepository extends JpaRepository<UserStoreFavorite, Long> {
+    boolean existsByUserIdAndStoreId(Long userId, Long storeId);
+}

--- a/honeybread-core/src/main/java/com/whatsub/honeybread/core/infra/errors/ErrorCode.java
+++ b/honeybread-core/src/main/java/com/whatsub/honeybread/core/infra/errors/ErrorCode.java
@@ -11,6 +11,11 @@ public enum ErrorCode {
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "-10002", "Bad Request"),
     VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "-10003", "Validation Error"),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "-10004", "Internal Server Error"),
+    UNAUTHENTICATED(HttpStatus.UNAUTHORIZED, "-10005", "Unauthenticated"),
+
+    DUPLICATE_USER_STORE_FAVORITE(HttpStatus.CONFLICT, "-21000", "Duplicate User Store Favorite"),
+
+    STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "-22000", "Store Not Found"),
     ;
     private final HttpStatus status;
     private final String code;

--- a/honeybread-core/src/test/java/com/whatsub/honeybread/core/domain/userstorefavorite/UserStoreFavoriteRepositoryTest.java
+++ b/honeybread-core/src/test/java/com/whatsub/honeybread/core/domain/userstorefavorite/UserStoreFavoriteRepositoryTest.java
@@ -1,0 +1,82 @@
+package com.whatsub.honeybread.core.domain.userstorefavorite;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+@ExtendWith(SpringExtension.class)
+@DataJpaTest
+class UserStoreFavoriteRepositoryTest {
+
+    private final long 유저아이디_1 = 1L;
+    private final long 유저아이디_2 = 2L;
+    private final long 스토어아이디_1 = 1L;
+    private final long 스토어아이디_2 = 2L;
+
+    @Autowired
+    private UserStoreFavoriteRepository userStoreFavoriteRepository;
+
+    @Test
+    void 유저아이디와_스토어아이디가_둘다_일치해야_조회_성공() {
+        // given
+        userStoreFavoriteRepository.save(new UserStoreFavorite(유저아이디_1, 스토어아이디_1));
+
+        // when
+        boolean 찜_존재_여부 = userStoreFavoriteRepository.existsByUserIdAndStoreId(유저아이디_1, 스토어아이디_1);
+
+        // then
+        assertThat(찜_존재_여부).isTrue();
+    }
+
+    @Test
+    void 찜정보를_등록한적_없으면_조회되지_않음() {
+        // given
+
+        // when
+        boolean 찜_존재_여부 = userStoreFavoriteRepository.existsByUserIdAndStoreId(유저아이디_1, 스토어아이디_1);
+
+        // then
+        assertThat(찜_존재_여부).isFalse();
+    }
+
+    @Test
+    void 스토어아이디가_다르면_유저의_스토어_찜정보가_조회되지_않음() {
+        // given
+        userStoreFavoriteRepository.save(new UserStoreFavorite(유저아이디_1, 스토어아이디_1));
+
+        // when
+        boolean 찜_존재_여부 = userStoreFavoriteRepository.existsByUserIdAndStoreId(유저아이디_1, 스토어아이디_2);
+
+        // then
+        assertThat(찜_존재_여부).isFalse();
+    }
+
+    @Test
+    void 유저아이디가_다르면_유저의_스토어_찜정보가_조회되지_않음() {
+        // given
+        userStoreFavoriteRepository.save(new UserStoreFavorite(유저아이디_1, 스토어아이디_1));
+
+        // when
+        boolean 찜_존재_여부 = userStoreFavoriteRepository.existsByUserIdAndStoreId(유저아이디_2, 스토어아이디_1);
+
+        // then
+        assertThat(찜_존재_여부).isFalse();
+    }
+
+    @Test
+    void 유저아이디와_스토어아이디가_다르면_유저의_스토어_찜정보가_조회되지_않음() {
+        // given
+        userStoreFavoriteRepository.save(new UserStoreFavorite(유저아이디_1, 스토어아이디_1));
+
+        // when
+        boolean 찜_존재_여부 = userStoreFavoriteRepository.existsByUserIdAndStoreId(유저아이디_2, 스토어아이디_2);
+
+        // then
+        assertThat(찜_존재_여부).isFalse();
+    }
+
+}

--- a/honeybread-core/src/test/java/com/whatsub/honeybread/core/domain/userstorefavorite/UserStoreFavoriteRepositoryTest.java
+++ b/honeybread-core/src/test/java/com/whatsub/honeybread/core/domain/userstorefavorite/UserStoreFavoriteRepositoryTest.java
@@ -1,14 +1,11 @@
 package com.whatsub.honeybread.core.domain.userstorefavorite;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
-@ExtendWith(SpringExtension.class)
 @DataJpaTest
 class UserStoreFavoriteRepositoryTest {
 

--- a/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/config/MgmtAdminMvcConfig.java
+++ b/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/config/MgmtAdminMvcConfig.java
@@ -1,8 +1,18 @@
 package com.whatsub.honeybread.mgmtadmin.config;
 
 import com.whatsub.honeybread.common.config.WebMvcConfig;
+import com.whatsub.honeybread.mgmtadmin.domain.userstorefavorite.ChannelUserSession;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.context.annotation.RequestScope;
 
 @Configuration
 public class MgmtAdminMvcConfig extends WebMvcConfig {
+
+    @Bean
+    @RequestScope
+    public ChannelUserSession channelUserSession() {
+        return new ChannelUserSession(1L);
+    }
+
 }

--- a/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/domain/userstorefavorite/ChannelUserSession.java
+++ b/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/domain/userstorefavorite/ChannelUserSession.java
@@ -1,10 +1,8 @@
 package com.whatsub.honeybread.mgmtadmin.domain.userstorefavorite;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.Value;
 
-@Getter
-@RequiredArgsConstructor
+@Value
 public class ChannelUserSession {
-    private final Long id;
+    private Long id;
 }

--- a/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/domain/userstorefavorite/ChannelUserSession.java
+++ b/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/domain/userstorefavorite/ChannelUserSession.java
@@ -1,0 +1,10 @@
+package com.whatsub.honeybread.mgmtadmin.domain.userstorefavorite;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ChannelUserSession {
+    private final Long id;
+}

--- a/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/domain/userstorefavorite/UserStoreFavoriteController.java
+++ b/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/domain/userstorefavorite/UserStoreFavoriteController.java
@@ -1,0 +1,34 @@
+package com.whatsub.honeybread.mgmtadmin.domain.userstorefavorite;
+
+import com.whatsub.honeybread.common.support.HoneyBreadSwaggerTags;
+import com.whatsub.honeybread.mgmtadmin.support.MgmtAdminSwaggerTags;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Api(tags = HoneyBreadSwaggerTags.ALL)
+@RestController
+@RequestMapping("stores/favorites")
+@RequiredArgsConstructor
+public class UserStoreFavoriteController {
+
+    private final UserStoreFavoriteService userStoreFavoriteService;
+    private final ChannelUserSession session;
+
+    @ApiOperation(
+            value = "유저-스토어 찜 등록",
+            tags = MgmtAdminSwaggerTags.USER_STORE_FAVORITE
+    )
+    @PostMapping("{storeId}")
+    public ResponseEntity createUserStoreFavorite(@PathVariable Long storeId) {
+        userStoreFavoriteService.create(session.getId(), storeId);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+}

--- a/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/domain/userstorefavorite/UserStoreFavoriteService.java
+++ b/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/domain/userstorefavorite/UserStoreFavoriteService.java
@@ -25,8 +25,7 @@ public class UserStoreFavoriteService {
         if (userStoreFavoriteRepository.existsByUserIdAndStoreId(userId, storeId)) {
             throw new HoneyBreadException(ErrorCode.DUPLICATE_USER_STORE_FAVORITE);
         }
-        UserStoreFavorite save = userStoreFavoriteRepository.save(new UserStoreFavorite(userId, storeId));
-        return save.getId();
+        return userStoreFavoriteRepository.save(new UserStoreFavorite(userId, storeId)).getId();
     }
 
 }

--- a/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/domain/userstorefavorite/UserStoreFavoriteService.java
+++ b/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/domain/userstorefavorite/UserStoreFavoriteService.java
@@ -1,0 +1,32 @@
+package com.whatsub.honeybread.mgmtadmin.domain.userstorefavorite;
+
+import com.whatsub.honeybread.core.domain.store.StoreRepository;
+import com.whatsub.honeybread.core.domain.userstorefavorite.UserStoreFavorite;
+import com.whatsub.honeybread.core.domain.userstorefavorite.UserStoreFavoriteRepository;
+import com.whatsub.honeybread.core.infra.errors.ErrorCode;
+import com.whatsub.honeybread.core.infra.exception.HoneyBreadException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserStoreFavoriteService {
+
+    private final UserStoreFavoriteRepository userStoreFavoriteRepository;
+    private final StoreRepository storeRepository;
+
+    @Transactional
+    public Long create(Long userId, Long storeId) {
+        if (!storeRepository.existsById(storeId)) {
+            throw new HoneyBreadException(ErrorCode.STORE_NOT_FOUND);
+        }
+        if (userStoreFavoriteRepository.existsByUserIdAndStoreId(userId, storeId)) {
+            throw new HoneyBreadException(ErrorCode.DUPLICATE_USER_STORE_FAVORITE);
+        }
+        UserStoreFavorite save = userStoreFavoriteRepository.save(new UserStoreFavorite(userId, storeId));
+        return save.getId();
+    }
+
+}

--- a/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/support/MgmtAdminSwaggerTags.java
+++ b/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/support/MgmtAdminSwaggerTags.java
@@ -2,4 +2,5 @@ package com.whatsub.honeybread.mgmtadmin.support;
 
 public abstract class MgmtAdminSwaggerTags {
     public static final String CATEGORY = "[01] 카테고리";
+    public static final String USER_STORE_FAVORITE = "[02] 유저 스토어 찜";
 }

--- a/honeybread-mgmtadmin/src/test/java/com/whatsub/honeybread/mgmtadmin/domain/userstorefavorite/UserStoreFavoriteControllerTest.java
+++ b/honeybread-mgmtadmin/src/test/java/com/whatsub/honeybread/mgmtadmin/domain/userstorefavorite/UserStoreFavoriteControllerTest.java
@@ -1,0 +1,67 @@
+package com.whatsub.honeybread.mgmtadmin.domain.userstorefavorite;
+
+import com.whatsub.honeybread.core.infra.errors.ErrorCode;
+import com.whatsub.honeybread.core.infra.exception.HoneyBreadException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UserStoreFavoriteController.class)
+class UserStoreFavoriteControllerTest {
+    static final String BASE_URL = "/stores/favorites";
+    static final String CREATE_URL = BASE_URL + "/" + 1L;
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockBean
+    UserStoreFavoriteService userStoreFavoriteService;
+
+    @Test
+    void 해당_스토어도_존재하고_찜한적도_없다면_등록_성공() throws Exception {
+        given(userStoreFavoriteService.create(anyLong(), anyLong())).willReturn(Long.MIN_VALUE);
+        ResultActions response = mockMvc.perform(post(CREATE_URL)).andDo(print());
+
+        verify(userStoreFavoriteService).create(anyLong(), anyLong());
+        response.andExpect(status().isCreated());
+    }
+
+    @Test
+    void 해당_스토어도_존재하지_않다면_등록_실패() throws Exception {
+        given(userStoreFavoriteService.create(anyLong(), anyLong())).willAnswer(mock -> {
+            throw new HoneyBreadException(ErrorCode.STORE_NOT_FOUND);
+        });
+
+        // when
+        ResultActions response = mockMvc.perform(post(CREATE_URL)).andDo(print());
+
+        // then
+        verify(userStoreFavoriteService).create(anyLong(), anyLong());
+        response.andExpect(status().isNotFound());
+    }
+
+    @Test
+    void 해당_스토어도_존재하는데_이미_찜했다면_등록_실패() throws Exception {
+        given(userStoreFavoriteService.create(anyLong(), anyLong())).willAnswer(mock -> {
+            throw new HoneyBreadException(ErrorCode.DUPLICATE_USER_STORE_FAVORITE);
+        });
+
+        // when
+        ResultActions response = mockMvc.perform(post(CREATE_URL)).andDo(print());
+
+        // then
+        verify(userStoreFavoriteService).create(anyLong(), anyLong());
+        response.andExpect(status().isConflict());
+    }
+
+}

--- a/honeybread-mgmtadmin/src/test/java/com/whatsub/honeybread/mgmtadmin/domain/userstorefavorite/UserStoreFavoriteControllerTest.java
+++ b/honeybread-mgmtadmin/src/test/java/com/whatsub/honeybread/mgmtadmin/domain/userstorefavorite/UserStoreFavoriteControllerTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -35,7 +36,7 @@ class UserStoreFavoriteControllerTest {
         });
 
         // when
-        ResultActions response = mockMvc.perform(post(CREATE_URL)).andDo(print());
+        ResultActions response = 찜등록_요청();
 
         // then
         verify(userStoreFavoriteService).create(anyLong(), anyLong());
@@ -48,7 +49,7 @@ class UserStoreFavoriteControllerTest {
         given(userStoreFavoriteService.create(anyLong(), anyLong())).willReturn(Long.MIN_VALUE);
 
         // when
-        ResultActions response = mockMvc.perform(post(CREATE_URL)).andDo(print());
+        ResultActions response = 찜등록_요청();
 
         // then
         verify(userStoreFavoriteService).create(anyLong(), anyLong());
@@ -63,11 +64,19 @@ class UserStoreFavoriteControllerTest {
         });
 
         // when
-        ResultActions response = mockMvc.perform(post(CREATE_URL)).andDo(print());
+        ResultActions response = 찜등록_요청();
 
         // then
         verify(userStoreFavoriteService).create(anyLong(), anyLong());
         response.andExpect(status().isConflict());
+    }
+
+    private ResultActions 찜등록_요청() throws Exception {
+        return mockMvc.perform(
+                post(CREATE_URL)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON)
+        ).andDo(print());
     }
 
 }

--- a/honeybread-mgmtadmin/src/test/java/com/whatsub/honeybread/mgmtadmin/domain/userstorefavorite/UserStoreFavoriteControllerTest.java
+++ b/honeybread-mgmtadmin/src/test/java/com/whatsub/honeybread/mgmtadmin/domain/userstorefavorite/UserStoreFavoriteControllerTest.java
@@ -28,16 +28,8 @@ class UserStoreFavoriteControllerTest {
     UserStoreFavoriteService userStoreFavoriteService;
 
     @Test
-    void 해당_스토어도_존재하고_찜한적도_없다면_등록_성공() throws Exception {
-        given(userStoreFavoriteService.create(anyLong(), anyLong())).willReturn(Long.MIN_VALUE);
-        ResultActions response = mockMvc.perform(post(CREATE_URL)).andDo(print());
-
-        verify(userStoreFavoriteService).create(anyLong(), anyLong());
-        response.andExpect(status().isCreated());
-    }
-
-    @Test
-    void 해당_스토어도_존재하지_않다면_등록_실패() throws Exception {
+    void 존재하지_않는_스토어면_등록_실패() throws Exception {
+        // given
         given(userStoreFavoriteService.create(anyLong(), anyLong())).willAnswer(mock -> {
             throw new HoneyBreadException(ErrorCode.STORE_NOT_FOUND);
         });
@@ -51,7 +43,21 @@ class UserStoreFavoriteControllerTest {
     }
 
     @Test
-    void 해당_스토어도_존재하는데_이미_찜했다면_등록_실패() throws Exception {
+    void 존재하는_스토어_그리고_찜한적_없으면_등록_성공() throws Exception {
+        // given
+        given(userStoreFavoriteService.create(anyLong(), anyLong())).willReturn(Long.MIN_VALUE);
+
+        // when
+        ResultActions response = mockMvc.perform(post(CREATE_URL)).andDo(print());
+
+        // then
+        verify(userStoreFavoriteService).create(anyLong(), anyLong());
+        response.andExpect(status().isCreated());
+    }
+
+    @Test
+    void 존재하는_스토어지만_이미_찜했기에_등록_실패() throws Exception {
+        // given
         given(userStoreFavoriteService.create(anyLong(), anyLong())).willAnswer(mock -> {
             throw new HoneyBreadException(ErrorCode.DUPLICATE_USER_STORE_FAVORITE);
         });

--- a/honeybread-mgmtadmin/src/test/java/com/whatsub/honeybread/mgmtadmin/domain/userstorefavorite/UserStoreFavoriteServiceTest.java
+++ b/honeybread-mgmtadmin/src/test/java/com/whatsub/honeybread/mgmtadmin/domain/userstorefavorite/UserStoreFavoriteServiceTest.java
@@ -1,0 +1,95 @@
+package com.whatsub.honeybread.mgmtadmin.domain.userstorefavorite;
+
+import com.whatsub.honeybread.core.domain.store.StoreRepository;
+import com.whatsub.honeybread.core.domain.userstorefavorite.UserStoreFavorite;
+import com.whatsub.honeybread.core.domain.userstorefavorite.UserStoreFavoriteRepository;
+import com.whatsub.honeybread.core.infra.errors.ErrorCode;
+import com.whatsub.honeybread.core.infra.exception.HoneyBreadException;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.TestConstructor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@SpringBootTest(classes = UserStoreFavoriteService.class)
+@RequiredArgsConstructor
+class UserStoreFavoriteServiceTest {
+
+    final UserStoreFavoriteService service;
+
+    @MockBean
+    UserStoreFavoriteRepository repository;
+
+    @MockBean
+    StoreRepository storeRepository;
+
+    @Test
+    void 스토어가_없으면_등록_실패() {
+        // given
+        해당_스토어는_없다();
+
+        // when
+        HoneyBreadException exception = assertThrows(HoneyBreadException.class, this::찜_등록);
+
+        // then
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.STORE_NOT_FOUND);
+    }
+
+    @Test
+    void 유저가_스토어를_찜한적_없으면_등록_성공() {
+        // given
+        해당_스토어가_있다();
+        찜한적_없다();
+        given(repository.save(any(UserStoreFavorite.class))).willReturn(mock(UserStoreFavorite.class));
+
+        // when
+        찜_등록();
+
+        // then
+        verify(repository).existsByUserIdAndStoreId(anyLong(), anyLong());
+        verify(repository).save(any(UserStoreFavorite.class));
+    }
+
+    @Test
+    void 유저가_스토어를_찜한적_있으면_등록_실패() {
+        // given
+        해당_스토어가_있다();
+        찜한적_있다();
+
+        // when
+        HoneyBreadException exception = assertThrows(HoneyBreadException.class, this::찜_등록);
+
+        // then
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.DUPLICATE_USER_STORE_FAVORITE);
+    }
+
+    private void 찜한적_없다() {
+        given(repository.existsByUserIdAndStoreId(anyLong(), anyLong())).willReturn(false);
+    }
+
+    private void 찜한적_있다() {
+        given(repository.existsByUserIdAndStoreId(anyLong(), anyLong())).willReturn(true);
+    }
+
+    private void 해당_스토어는_없다() {
+        given(storeRepository.existsById(anyLong())).willReturn(false);
+    }
+
+    private void 해당_스토어가_있다() {
+        given(storeRepository.existsById(anyLong())).willReturn(true);
+    }
+
+    private void 찜_등록() {
+        service.create(1L, 1L);
+    }
+
+}

--- a/honeybread-mgmtadmin/src/test/java/com/whatsub/honeybread/mgmtadmin/domain/userstorefavorite/UserStoreFavoriteServiceTest.java
+++ b/honeybread-mgmtadmin/src/test/java/com/whatsub/honeybread/mgmtadmin/domain/userstorefavorite/UserStoreFavoriteServiceTest.java
@@ -33,9 +33,9 @@ class UserStoreFavoriteServiceTest {
     StoreRepository storeRepository;
 
     @Test
-    void 스토어가_없으면_등록_실패() {
+    void 존재하지_않는_스토어면_등록_실패() {
         // given
-        해당_스토어는_없다();
+        존재하지_않는_스토어();
 
         // when
         HoneyBreadException exception = assertThrows(HoneyBreadException.class, this::찜_등록);
@@ -45,10 +45,10 @@ class UserStoreFavoriteServiceTest {
     }
 
     @Test
-    void 유저가_스토어를_찜한적_없으면_등록_성공() {
+    void 존재하는_스토어_그리고_찜한적_없으면_등록_성공() {
         // given
-        해당_스토어가_있다();
-        찜한적_없다();
+        존재하는_스토어();
+        찜한적_없음();
         given(repository.save(any(UserStoreFavorite.class))).willReturn(mock(UserStoreFavorite.class));
 
         // when
@@ -60,10 +60,10 @@ class UserStoreFavoriteServiceTest {
     }
 
     @Test
-    void 유저가_스토어를_찜한적_있으면_등록_실패() {
+    void 존재하는_스토어지만_이미_찜했기에_등록_실패() {
         // given
-        해당_스토어가_있다();
-        찜한적_있다();
+        존재하는_스토어();
+        이미_찜했음();
 
         // when
         HoneyBreadException exception = assertThrows(HoneyBreadException.class, this::찜_등록);
@@ -72,20 +72,20 @@ class UserStoreFavoriteServiceTest {
         assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.DUPLICATE_USER_STORE_FAVORITE);
     }
 
-    private void 찜한적_없다() {
-        given(repository.existsByUserIdAndStoreId(anyLong(), anyLong())).willReturn(false);
-    }
-
-    private void 찜한적_있다() {
-        given(repository.existsByUserIdAndStoreId(anyLong(), anyLong())).willReturn(true);
-    }
-
-    private void 해당_스토어는_없다() {
+    private void 존재하지_않는_스토어() {
         given(storeRepository.existsById(anyLong())).willReturn(false);
     }
 
-    private void 해당_스토어가_있다() {
+    private void 존재하는_스토어() {
         given(storeRepository.existsById(anyLong())).willReturn(true);
+    }
+
+    private void 찜한적_없음() {
+        given(repository.existsByUserIdAndStoreId(anyLong(), anyLong())).willReturn(false);
+    }
+
+    private void 이미_찜했음() {
+        given(repository.existsByUserIdAndStoreId(anyLong(), anyLong())).willReturn(true);
     }
 
     private void 찜_등록() {


### PR DESCRIPTION
쉬운 유저-스토어 찜부터 하려고 했는데 생각해보니 유저가 찜을 하는 건 어드민이 아니라 전시더라구요..
사실 유저-스토어 찜 요청은 api 콜을 할 때 userId, storeId를 넘기는 게 아니라
storeId만 넘기고 userId는 인증된 id를 써야하는데..
그래서 일단 리퀘스트 스코프로 1L 박아버렸습니다 :(
혹시 어떻게 진행하는 게 좋을까여 ㅠ,ㅠ