### PR TITLE
[Develop] 최근배달주소 기능

### DIFF
--- a/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/recentaddress/RecentDeliveryAddress.java
+++ b/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/recentaddress/RecentDeliveryAddress.java
@@ -14,9 +14,8 @@ import java.time.LocalDateTime;
 @EqualsAndHashCode(callSuper = true)
 public class RecentDeliveryAddress extends BaseEntity {
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
-    private User user;
+    @Column(nullable = false)
+    private Long userId;
 
     @Column(nullable = false)
     private String deliveryAddress;
@@ -34,13 +33,13 @@ public class RecentDeliveryAddress extends BaseEntity {
     private LocalDateTime usedAt;
 
     @Builder
-    public RecentDeliveryAddress (User user,
+    public RecentDeliveryAddress (Long userId,
                                   String deliveryAddress,
                                   String searchableDeliveryAddress,
                                   String stateNameAddress,
                                   String zipCode,
                                   LocalDateTime usedAt) {
-        this.user = user;
+        this.userId = userId;
         this.deliveryAddress = deliveryAddress;
         this.searchableDeliveryAddress = searchableDeliveryAddress;
         this.stateNameAddress = stateNameAddress;

--- a/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/recentaddress/RecentDeliveryAddress.java
+++ b/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/recentaddress/RecentDeliveryAddress.java
@@ -1,0 +1,50 @@
+package com.whatsub.honeybread.core.domain.recentaddress;
+
+import com.whatsub.honeybread.core.domain.base.BaseEntity;
+import com.whatsub.honeybread.core.domain.user.User;
+import lombok.*;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "recent_delivery_address")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode(callSuper = true)
+public class RecentDeliveryAddress extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(nullable = false)
+    private String deliveryAddress;
+
+    @Column(nullable = false)
+    private String searchableDeliveryAddress;
+
+    @Column(nullable = false)
+    private String stateNameAddress;
+
+    @Column(nullable = false)
+    private String zipCode;
+
+    @Column(nullable = false)
+    private LocalDateTime usedAt;
+
+    @Builder
+    public RecentDeliveryAddress (User user,
+                                  String deliveryAddress,
+                                  String searchableDeliveryAddress,
+                                  String stateNameAddress,
+                                  String zipCode,
+                                  LocalDateTime usedAt) {
+        this.user = user;
+        this.deliveryAddress = deliveryAddress;
+        this.searchableDeliveryAddress = searchableDeliveryAddress;
+        this.stateNameAddress = stateNameAddress;
+        this.zipCode = zipCode;
+        this.usedAt = usedAt;
+    }
+}

--- a/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/recentaddress/RecentDeliveryAddress.java
+++ b/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/recentaddress/RecentDeliveryAddress.java
@@ -1,16 +1,21 @@
 package com.whatsub.honeybread.core.domain.recentaddress;
 
 import com.whatsub.honeybread.core.domain.base.BaseEntity;
-import com.whatsub.honeybread.core.domain.user.User;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Table;
 import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "recent_delivery_address")
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 @EqualsAndHashCode(callSuper = true)
 public class RecentDeliveryAddress extends BaseEntity {
 

--- a/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/recentaddress/RecentDeliveryAddress.java
+++ b/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/recentaddress/RecentDeliveryAddress.java
@@ -38,7 +38,7 @@ public class RecentDeliveryAddress extends BaseEntity {
     private LocalDateTime usedAt;
 
     @Builder
-    public RecentDeliveryAddress (Long userId,
+    private RecentDeliveryAddress (Long userId,
                                   String deliveryAddress,
                                   String searchableDeliveryAddress,
                                   String stateNameAddress,

--- a/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/recentaddress/RecentDeliveryAddress.java
+++ b/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/recentaddress/RecentDeliveryAddress.java
@@ -51,4 +51,8 @@ public class RecentDeliveryAddress extends BaseEntity {
         this.zipCode = zipCode;
         this.usedAt = usedAt;
     }
+
+    public void updateUsedAt() {
+        this.usedAt = LocalDateTime.now();
+    }
 }

--- a/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/recentaddress/RecentDeliveryAddressRepository.java
+++ b/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/recentaddress/RecentDeliveryAddressRepository.java
@@ -2,8 +2,10 @@ package com.whatsub.honeybread.core.domain.recentaddress;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface RecentDeliveryAddressRepository extends JpaRepository<RecentDeliveryAddress, Long> {
     Optional<RecentDeliveryAddress> findByUserIdAndDeliveryAddressOrStateNameAddress(Long userId, String deliveryAddress, String stateNameAddress);
+    List<RecentDeliveryAddress> findAllByUserId(Long userId);
 }

--- a/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/recentaddress/RecentDeliveryAddressRepository.java
+++ b/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/recentaddress/RecentDeliveryAddressRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 public interface RecentDeliveryAddressRepository extends JpaRepository<RecentDeliveryAddress, Long> {
     Optional<RecentDeliveryAddress> findByUserIdAndDeliveryAddressOrStateNameAddress(Long userId, String deliveryAddress, String stateNameAddress);
     List<RecentDeliveryAddress> findAllByUserId(Long userId);
+    int countByUserId(Long userId);
+    Optional<RecentDeliveryAddress> findTop1ByUserIdOrderByUsedAtAsc(Long userId);
 }

--- a/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/recentaddress/RecentDeliveryAddressRepository.java
+++ b/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/recentaddress/RecentDeliveryAddressRepository.java
@@ -1,10 +1,9 @@
 package com.whatsub.honeybread.core.domain.recentaddress;
 
-import com.whatsub.honeybread.core.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface RecentDeliveryAddressRepository extends JpaRepository<RecentDeliveryAddress, Long> {
-    Optional<RecentDeliveryAddress> findByUserAndDeliveryAddressOrStateNameAddress(User user, String deliveryAddress, String stateNameAddress);
+    Optional<RecentDeliveryAddress> findByUserIdAndDeliveryAddressOrStateNameAddress(Long userId, String deliveryAddress, String stateNameAddress);
 }

--- a/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/recentaddress/RecentDeliveryAddressRepository.java
+++ b/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/recentaddress/RecentDeliveryAddressRepository.java
@@ -1,0 +1,10 @@
+package com.whatsub.honeybread.core.domain.recentaddress;
+
+import com.whatsub.honeybread.core.domain.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RecentDeliveryAddressRepository extends JpaRepository<RecentDeliveryAddress, Long> {
+    Optional<RecentDeliveryAddress> findByUserAndDeliveryAddressOrStateNameAddress(User user, String deliveryAddress, String stateNameAddress);
+}

--- a/honeybread-core/src/main/java/com/whatsub/honeybread/core/infra/errors/ErrorCode.java
+++ b/honeybread-core/src/main/java/com/whatsub/honeybread/core/infra/errors/ErrorCode.java
@@ -23,6 +23,8 @@ public enum ErrorCode {
     USER_STORE_FAVORITE_NOT_FOUND(HttpStatus.NOT_FOUND, "-21001", "User Store Favorite Not Found"),
 
     STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "-22000", "Store Not Found"),
+
+    RECENT_DELIVERY_ADDRESS_NOT_FOUND(HttpStatus.NOT_FOUND, "40001", "Recent Delivery Address Not Found"),
     ;
     private final HttpStatus status;
     private final String code;

--- a/honeybread-core/src/test/java/com/whatsub/honeybread/core/domain/recentaddress/RecentDeliveryAddressRepositoryTest.java
+++ b/honeybread-core/src/test/java/com/whatsub/honeybread/core/domain/recentaddress/RecentDeliveryAddressRepositoryTest.java
@@ -1,0 +1,87 @@
+package com.whatsub.honeybread.core.domain.recentaddress;
+
+import com.whatsub.honeybread.core.domain.user.User;
+import com.whatsub.honeybread.core.domain.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.TestConstructor;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@DataJpaTest
+@RequiredArgsConstructor
+class RecentDeliveryAddressRepositoryTest {
+
+    final RecentDeliveryAddressRepository repository;
+    final UserRepository userRepository;
+
+    @Test
+    void 배달주소로_최근배달주소검색() {
+        //given
+        User user = createUser();
+        userRepository.save(user);
+
+        String deliveryAddress = "서울시 강남구 수서동 500 301동 404호";
+
+        RecentDeliveryAddress recentDeliveryAddress = RecentDeliveryAddress.builder()
+            .user(user)
+            .deliveryAddress(deliveryAddress)
+            .searchableDeliveryAddress("서울시 강남구 수서동")
+            .stateNameAddress("서울시 강남구 광평로101길 200 301호 404호")
+            .zipCode("99999")
+            .usedAt(LocalDateTime.now())
+            .build();
+
+        repository.save(recentDeliveryAddress);
+
+        //when
+        Optional<RecentDeliveryAddress> findRecentDeliveryAddress =
+            repository.findByUserAndDeliveryAddressOrStateNameAddress(user, deliveryAddress, "");
+
+        //then
+        assertTrue(findRecentDeliveryAddress.isPresent());
+        assertEquals(recentDeliveryAddress, findRecentDeliveryAddress.get());
+    }
+
+    @Test
+    void 도로명주소로로_최근배달주소검색() {
+        //given
+        User user = createUser();
+        userRepository.save(user);
+
+        String stateNameAddress = "서울시 강남구 광평로101길 200 301호 404호";
+
+        RecentDeliveryAddress recentDeliveryAddress = RecentDeliveryAddress.builder()
+            .user(user)
+            .deliveryAddress("서울시 강남구 수서동 500 301동 404호")
+            .searchableDeliveryAddress("서울시 강남구 수서동")
+            .stateNameAddress(stateNameAddress)
+            .zipCode("99999")
+            .usedAt(LocalDateTime.now())
+            .build();
+
+        repository.save(recentDeliveryAddress);
+
+        //when
+        Optional<RecentDeliveryAddress> findRecentDeliveryAddress
+            = repository.findByUserAndDeliveryAddressOrStateNameAddress(user, "", stateNameAddress);
+
+        //then
+        assertTrue(findRecentDeliveryAddress.isPresent());
+        assertEquals(recentDeliveryAddress, findRecentDeliveryAddress.get());
+    }
+
+    private User createUser() {
+        return User.createUser("test@honeybread.com",
+            "testpasswd",
+            "010-0000-0000",
+            true,
+            true);
+    }
+}

--- a/honeybread-core/src/test/java/com/whatsub/honeybread/core/domain/recentaddress/RecentDeliveryAddressRepositoryTest.java
+++ b/honeybread-core/src/test/java/com/whatsub/honeybread/core/domain/recentaddress/RecentDeliveryAddressRepositoryTest.java
@@ -2,12 +2,14 @@ package com.whatsub.honeybread.core.domain.recentaddress;
 
 import com.whatsub.honeybread.core.domain.user.UserRepository;
 import lombok.RequiredArgsConstructor;
-import org.h2.util.ThreadDeadlockDetector;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.TestConstructor;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.Month;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.IntStream;
@@ -86,6 +88,51 @@ class RecentDeliveryAddressRepositoryTest {
 
         //then
         assertEquals(10, recentDeliveryAddresses.size());
+    }
+
+    @Test
+    public void UserId로_최근배달주소들_개수_검색() {
+        //given
+        final long userId = 1L;
+        사이즈만큼_최근배달주소_등록(10, userId);
+
+        //when
+        int count = repository.countByUserId(userId);
+
+        //then
+        assertEquals(10, count);
+    }
+
+    @Test
+    public void UserId로_최근배달주소들중_가장_오래된_최근배달주소_검색() {
+        //given
+        final long userId = 1L;
+        final RecentDeliveryAddress old = RecentDeliveryAddress.builder()
+            .userId(userId)
+            .deliveryAddress("서울시 강남구 수서동 500 301동 404호")
+            .searchableDeliveryAddress("서울시 강남구 수서동")
+            .stateNameAddress("서울시 강남구 광평로101길 200 301호 404호")
+            .zipCode("99999")
+            .usedAt(LocalDateTime.of(LocalDate.of(2020, Month.SEPTEMBER, 30), LocalTime.now()))
+            .build();
+
+        final RecentDeliveryAddress recentDeliveryAddress = RecentDeliveryAddress.builder()
+            .userId(userId)
+            .deliveryAddress("서울시 강남구 수서동 500 301동 500호")
+            .searchableDeliveryAddress("서울시 강남구 수서동")
+            .stateNameAddress("서울시 강남구 광평로101길 200 301호 500호")
+            .zipCode("99999")
+            .usedAt(LocalDateTime.of(LocalDate.of(2021, Month.JANUARY, 31), LocalTime.now()))
+            .build();
+
+        repository.saveAll(List.of(old,recentDeliveryAddress));
+
+        //when
+        Optional<RecentDeliveryAddress> findRecentDeliveryAddress = repository.findTop1ByUserIdOrderByUsedAtAsc(userId);
+
+        //then
+        assertTrue(findRecentDeliveryAddress.isPresent());
+        assertEquals(old, findRecentDeliveryAddress.get());
     }
 
     private void 사이즈만큼_최근배달주소_등록(int i, long userId) {

--- a/honeybread-core/src/test/java/com/whatsub/honeybread/core/domain/recentaddress/RecentDeliveryAddressRepositoryTest.java
+++ b/honeybread-core/src/test/java/com/whatsub/honeybread/core/domain/recentaddress/RecentDeliveryAddressRepositoryTest.java
@@ -2,12 +2,15 @@ package com.whatsub.honeybread.core.domain.recentaddress;
 
 import com.whatsub.honeybread.core.domain.user.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.h2.util.ThreadDeadlockDetector;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.TestConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -72,4 +75,29 @@ class RecentDeliveryAddressRepositoryTest {
         assertEquals(recentDeliveryAddress, findRecentDeliveryAddress.get());
     }
 
+    @Test
+    public void UserId로_최근배달주소들_검색() {
+        //given
+        final long userId = 1L;
+        사이즈만큼_최근배달주소_등록(10, userId);
+
+        //when
+        List<RecentDeliveryAddress> recentDeliveryAddresses = repository.findAllByUserId(userId);
+
+        //then
+        assertEquals(10, recentDeliveryAddresses.size());
+    }
+
+    private void 사이즈만큼_최근배달주소_등록(int i, long userId) {
+        IntStream.range(0, i)
+            .mapToObj((v) -> RecentDeliveryAddress.builder()
+                .userId(userId)
+                .deliveryAddress("서울시 강남구 수서동 500 301동 404호 " + v)
+                .searchableDeliveryAddress("서울시 강남구 수서동")
+                .stateNameAddress("서울시 강남구 광평로101길 200 301호 404호" + v)
+                .zipCode("99999")
+                .usedAt(LocalDateTime.now())
+                .build())
+            .forEach(repository::save);
+    }
 }

--- a/honeybread-core/src/test/java/com/whatsub/honeybread/core/domain/recentaddress/RecentDeliveryAddressRepositoryTest.java
+++ b/honeybread-core/src/test/java/com/whatsub/honeybread/core/domain/recentaddress/RecentDeliveryAddressRepositoryTest.java
@@ -1,6 +1,5 @@
 package com.whatsub.honeybread.core.domain.recentaddress;
 
-import com.whatsub.honeybread.core.domain.user.User;
 import com.whatsub.honeybread.core.domain.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.Test;
@@ -24,13 +23,11 @@ class RecentDeliveryAddressRepositoryTest {
     @Test
     void 배달주소로_최근배달주소검색() {
         //given
-        User user = createUser();
-        userRepository.save(user);
+        final long userId = 1L;
+        final String deliveryAddress = "서울시 강남구 수서동 500 301동 404호";
 
-        String deliveryAddress = "서울시 강남구 수서동 500 301동 404호";
-
-        RecentDeliveryAddress recentDeliveryAddress = RecentDeliveryAddress.builder()
-            .user(user)
+        final RecentDeliveryAddress recentDeliveryAddress = RecentDeliveryAddress.builder()
+            .userId(userId)
             .deliveryAddress(deliveryAddress)
             .searchableDeliveryAddress("서울시 강남구 수서동")
             .stateNameAddress("서울시 강남구 광평로101길 200 301호 404호")
@@ -42,7 +39,7 @@ class RecentDeliveryAddressRepositoryTest {
 
         //when
         Optional<RecentDeliveryAddress> findRecentDeliveryAddress =
-            repository.findByUserAndDeliveryAddressOrStateNameAddress(user, deliveryAddress, "");
+            repository.findByUserIdAndDeliveryAddressOrStateNameAddress(userId, deliveryAddress, "");
 
         //then
         assertTrue(findRecentDeliveryAddress.isPresent());
@@ -52,13 +49,11 @@ class RecentDeliveryAddressRepositoryTest {
     @Test
     void 도로명주소로로_최근배달주소검색() {
         //given
-        User user = createUser();
-        userRepository.save(user);
+        final long userId = 1L;
+        final String stateNameAddress = "서울시 강남구 광평로101길 200 301호 404호";
 
-        String stateNameAddress = "서울시 강남구 광평로101길 200 301호 404호";
-
-        RecentDeliveryAddress recentDeliveryAddress = RecentDeliveryAddress.builder()
-            .user(user)
+        final RecentDeliveryAddress recentDeliveryAddress = RecentDeliveryAddress.builder()
+            .userId(userId)
             .deliveryAddress("서울시 강남구 수서동 500 301동 404호")
             .searchableDeliveryAddress("서울시 강남구 수서동")
             .stateNameAddress(stateNameAddress)
@@ -70,18 +65,11 @@ class RecentDeliveryAddressRepositoryTest {
 
         //when
         Optional<RecentDeliveryAddress> findRecentDeliveryAddress
-            = repository.findByUserAndDeliveryAddressOrStateNameAddress(user, "", stateNameAddress);
+            = repository.findByUserIdAndDeliveryAddressOrStateNameAddress(userId, "", stateNameAddress);
 
         //then
         assertTrue(findRecentDeliveryAddress.isPresent());
         assertEquals(recentDeliveryAddress, findRecentDeliveryAddress.get());
     }
 
-    private User createUser() {
-        return User.createUser("test@honeybread.com",
-            "testpasswd",
-            "010-0000-0000",
-            true,
-            true);
-    }
 }

--- a/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/domain/recentaddress/RecentDeliveryAddressQueryService.java
+++ b/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/domain/recentaddress/RecentDeliveryAddressQueryService.java
@@ -1,0 +1,22 @@
+package com.whatsub.honeybread.mgmtadmin.domain.recentaddress;
+
+import com.whatsub.honeybread.core.domain.recentaddress.RecentDeliveryAddress;
+import com.whatsub.honeybread.core.domain.recentaddress.RecentDeliveryAddressRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+@Transactional(readOnly = true)
+public class RecentDeliveryAddressQueryService {
+
+    private final RecentDeliveryAddressRepository repository;
+
+    public List<RecentDeliveryAddress> getRecentDeliveryAddressesByUserId(Long id) {
+        return repository.findAllByUserId(id);
+    }
+
+}

--- a/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/domain/recentaddress/RecentDeliveryAddressService.java
+++ b/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/domain/recentaddress/RecentDeliveryAddressService.java
@@ -27,11 +27,11 @@ public class RecentDeliveryAddressService {
     }
 
     @Transactional
-    public void delete(long id) {
+    public void delete(Long id) {
         repository.delete(findById(id));
     }
 
-    public RecentDeliveryAddress findById(long id) {
+    public RecentDeliveryAddress findById(Long id) {
         return repository.findById(id)
             .orElseThrow(() -> new HoneyBreadException(ErrorCode.RECENT_DELIVERY_ADDRESS_NOT_FOUND));
     }

--- a/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/domain/recentaddress/RecentDeliveryAddressService.java
+++ b/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/domain/recentaddress/RecentDeliveryAddressService.java
@@ -22,8 +22,17 @@ public class RecentDeliveryAddressService {
             repository.findByUserIdAndDeliveryAddressOrStateNameAddress(request.getUserId(),
                                                                         request.getDeliveryAddress(),
                                                                         request.getStateNameAddress())
-                    .orElseGet(() -> repository.save(request.toRecentDeliveryAddress()));
+                    .orElseGet(() -> {
+                        deleteIfCountGreaterThanOrEqual10(repository.countByUserId(request.getUserId()), request.getUserId());
+                        return repository.save(request.toRecentDeliveryAddress());
+                    });
         recentDeliveryAddress.updateUsedAt();
+    }
+
+    private void deleteIfCountGreaterThanOrEqual10(int count, Long userId) {
+        if(count >= 10) {
+            repository.delete(repository.findTop1ByUserIdOrderByUsedAtAsc(userId).get());
+        }
     }
 
     @Transactional

--- a/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/domain/recentaddress/RecentDeliveryAddressService.java
+++ b/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/domain/recentaddress/RecentDeliveryAddressService.java
@@ -1,0 +1,23 @@
+package com.whatsub.honeybread.mgmtadmin.domain.recentaddress;
+
+import com.whatsub.honeybread.core.domain.recentaddress.RecentDeliveryAddress;
+import com.whatsub.honeybread.core.domain.recentaddress.RecentDeliveryAddressRepository;
+import com.whatsub.honeybread.mgmtadmin.domain.recentaddress.dto.RecentDeliveryAddressServiceRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+@Transactional(readOnly = true)
+public class RecentDeliveryAddressService {
+
+    private final RecentDeliveryAddressRepository repository;
+
+    @Transactional
+    public void createIfAbsent(RecentDeliveryAddressServiceRequest request) {
+        RecentDeliveryAddress recentDeliveryAddress = repository.findByUserIdAndDeliveryAddressOrStateNameAddress(request.getUserId(), request.getDeliveryAddress(), request.getStateNameAddress())
+            .orElseGet(() -> repository.save(request.toRecentDeliveryAddress()));
+        recentDeliveryAddress.updateUsedAt();
+    }
+}

--- a/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/domain/recentaddress/RecentDeliveryAddressService.java
+++ b/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/domain/recentaddress/RecentDeliveryAddressService.java
@@ -2,6 +2,8 @@ package com.whatsub.honeybread.mgmtadmin.domain.recentaddress;
 
 import com.whatsub.honeybread.core.domain.recentaddress.RecentDeliveryAddress;
 import com.whatsub.honeybread.core.domain.recentaddress.RecentDeliveryAddressRepository;
+import com.whatsub.honeybread.core.infra.errors.ErrorCode;
+import com.whatsub.honeybread.core.infra.exception.HoneyBreadException;
 import com.whatsub.honeybread.mgmtadmin.domain.recentaddress.dto.RecentDeliveryAddressServiceRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,8 +18,21 @@ public class RecentDeliveryAddressService {
 
     @Transactional
     public void createIfAbsent(RecentDeliveryAddressServiceRequest request) {
-        RecentDeliveryAddress recentDeliveryAddress = repository.findByUserIdAndDeliveryAddressOrStateNameAddress(request.getUserId(), request.getDeliveryAddress(), request.getStateNameAddress())
-            .orElseGet(() -> repository.save(request.toRecentDeliveryAddress()));
+        RecentDeliveryAddress recentDeliveryAddress =
+            repository.findByUserIdAndDeliveryAddressOrStateNameAddress(request.getUserId(),
+                                                                        request.getDeliveryAddress(),
+                                                                        request.getStateNameAddress())
+                    .orElseGet(() -> repository.save(request.toRecentDeliveryAddress()));
         recentDeliveryAddress.updateUsedAt();
+    }
+
+    @Transactional
+    public void delete(long id) {
+        repository.delete(findById(id));
+    }
+
+    public RecentDeliveryAddress findById(long id) {
+        return repository.findById(id)
+            .orElseThrow(() -> new HoneyBreadException(ErrorCode.RECENT_DELIVERY_ADDRESS_NOT_FOUND));
     }
 }

--- a/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/domain/recentaddress/dto/RecentDeliveryAddressServiceRequest.java
+++ b/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/domain/recentaddress/dto/RecentDeliveryAddressServiceRequest.java
@@ -1,0 +1,31 @@
+package com.whatsub.honeybread.mgmtadmin.domain.recentaddress.dto;
+
+import com.whatsub.honeybread.core.domain.recentaddress.RecentDeliveryAddress;
+import lombok.Value;
+
+import java.time.LocalDateTime;
+
+@Value
+public class RecentDeliveryAddressServiceRequest {
+
+    Long userId;
+
+    String deliveryAddress;
+
+    String searchableDeliveryAddress;
+
+    String stateNameAddress;
+
+    String zipCode;
+
+    public RecentDeliveryAddress toRecentDeliveryAddress() {
+        return RecentDeliveryAddress.builder()
+            .usedAt(LocalDateTime.now())
+            .zipCode(this.zipCode)
+            .stateNameAddress(this.stateNameAddress)
+            .searchableDeliveryAddress(this.searchableDeliveryAddress)
+            .deliveryAddress(this.deliveryAddress)
+            .userId(userId)
+            .build();
+    }
+}

--- a/honeybread-mgmtadmin/src/test/java/com/whatsub/honeybread/mgmtadmin/domain/recentaddress/RecentDeliveryAddressQueryServiceTest.java
+++ b/honeybread-mgmtadmin/src/test/java/com/whatsub/honeybread/mgmtadmin/domain/recentaddress/RecentDeliveryAddressQueryServiceTest.java
@@ -1,0 +1,56 @@
+package com.whatsub.honeybread.mgmtadmin.domain.recentaddress;
+
+import com.whatsub.honeybread.core.domain.recentaddress.RecentDeliveryAddress;
+import com.whatsub.honeybread.core.domain.recentaddress.RecentDeliveryAddressRepository;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.TestConstructor;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@SpringBootTest(classes = RecentDeliveryAddressQueryService.class)
+@RequiredArgsConstructor
+class RecentDeliveryAddressQueryServiceTest {
+
+    final RecentDeliveryAddressQueryService service;
+
+    @MockBean
+    RecentDeliveryAddressRepository repository;
+
+    @Mock
+    List<RecentDeliveryAddress> mockList;
+
+    @Test
+    void UserId로_최근배달주소들_검색() {
+        //given
+        int expectSize = 10;
+        사이즈만큼_최근배달주소들_검색(expectSize);
+
+        //when
+        List<RecentDeliveryAddress> recentDeliveryAddresses =
+            service.getRecentDeliveryAddressesByUserId(1L);
+
+        //then
+        UserId로_최근배달주소들_검색되어야함();
+        assertEquals(expectSize, recentDeliveryAddresses.size());
+    }
+
+    private void 사이즈만큼_최근배달주소들_검색(int expectSize) {
+        given(mockList.size()).willReturn(expectSize);
+        given(repository.findAllByUserId(anyLong()))
+            .willReturn(mockList);
+    }
+
+    private void UserId로_최근배달주소들_검색되어야함() {
+        then(repository).should().findAllByUserId(anyLong());
+    }
+}

--- a/honeybread-mgmtadmin/src/test/java/com/whatsub/honeybread/mgmtadmin/domain/recentaddress/RecentDeliveryAddressServiceTest.java
+++ b/honeybread-mgmtadmin/src/test/java/com/whatsub/honeybread/mgmtadmin/domain/recentaddress/RecentDeliveryAddressServiceTest.java
@@ -2,6 +2,8 @@ package com.whatsub.honeybread.mgmtadmin.domain.recentaddress;
 
 import com.whatsub.honeybread.core.domain.recentaddress.RecentDeliveryAddress;
 import com.whatsub.honeybread.core.domain.recentaddress.RecentDeliveryAddressRepository;
+import com.whatsub.honeybread.core.infra.errors.ErrorCode;
+import com.whatsub.honeybread.core.infra.exception.HoneyBreadException;
 import com.whatsub.honeybread.mgmtadmin.domain.recentaddress.dto.RecentDeliveryAddressServiceRequest;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.Test;
@@ -12,6 +14,8 @@ import org.springframework.test.context.TestConstructor;
 
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -66,6 +70,66 @@ class RecentDeliveryAddressServiceTest {
         주소_사용시간이_업데이트되어야함();
     }
 
+    @Test
+    void 주소_삭제() {
+        //given
+        주소_ID_검색_성공();
+
+        //when
+        service.delete(anyLong());
+
+        //then
+        주소가_삭제되어야함();
+    }
+
+    @Test
+    void 주소_삭제시_없을경우_에러() {
+        //given
+        주소_ID_검색_실패();
+
+        //when
+        HoneyBreadException honeyBreadException =
+            assertThrows(HoneyBreadException.class, () -> service.delete(anyLong()));
+
+        //then
+        RECENT_DELIVERY_ADDRESS_NOT_FOUND_에러_발생(honeyBreadException);
+    }
+
+    @Test
+    void 주소_ID_검색() {
+        //given
+        주소_ID_검색_성공();
+
+        //when
+        repository.findById(anyLong());
+
+        //then
+        주소가_ID로_검색되어야함();
+    }
+
+    @Test
+    void 주소_ID_검색시_없을경우_에러() {
+        //given
+        주소_ID_검색_실패();
+
+        //when
+        HoneyBreadException honeyBreadException =
+            assertThrows(HoneyBreadException.class, () -> service.delete(anyLong()));
+
+        //then
+        RECENT_DELIVERY_ADDRESS_NOT_FOUND_에러_발생(honeyBreadException);
+    }
+
+    private void 주소_ID_검색_성공() {
+        given(repository.findById(anyLong()))
+            .willReturn(Optional.of(mockEntity));
+    }
+
+    private void 주소_ID_검색_실패() {
+        given(repository.findById(anyLong()))
+            .willReturn(Optional.empty());
+    }
+
     private void 주소_요청() {
         given(mockRequest.getUserId()).willReturn(1L);
         given(mockRequest.getDeliveryAddress()).willReturn("서울시 강남구 수서동 500 301동 404호");
@@ -101,5 +165,19 @@ class RecentDeliveryAddressServiceTest {
 
     private void 주소_등록이_실행되지_않아야함() {
         then(repository).should(never()).save(any(RecentDeliveryAddress.class));
+    }
+
+    private void 주소가_삭제되어야함() {
+        then(repository).should().delete(any(RecentDeliveryAddress.class));
+    }
+
+    private void 주소가_ID로_검색되어야함() {
+        then(repository).should().findById(anyLong());
+    }
+
+    private void RECENT_DELIVERY_ADDRESS_NOT_FOUND_에러_발생(HoneyBreadException honeyBreadException) {
+        assertEquals(ErrorCode.RECENT_DELIVERY_ADDRESS_NOT_FOUND.getMessage(), honeyBreadException.getErrorCode().getMessage());
+        assertEquals(ErrorCode.RECENT_DELIVERY_ADDRESS_NOT_FOUND.getCode(), honeyBreadException.getErrorCode().getCode());
+        assertEquals(ErrorCode.RECENT_DELIVERY_ADDRESS_NOT_FOUND.getStatus(), honeyBreadException.getErrorCode().getStatus());
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>3.3.3</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
배달의민족에서 배달받을 위치를 설정할때는 도로명 또는 지번을 기준으로 동작하더라구요

그래서 도로명(서울시 강남구 광평로101길 200 301호 404호) 또는 지번(서울시 강남구 수서동 500 301동 404호)이 한개라도 일치하면 기존에 있던 row의 사용시간을 update치고 아니라면 새롭게 row를 넣어주는 방식으로 개발할 것 같습니다~

혹시 다른 의견 있으시면 말씀해주세요!