### PR TITLE
[ Develop ] mockito inline dependency (final 클래스 모킹을 위함)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>3.3.3</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
XXRequest 도 mock으로 만들고싶은데 mockito-core 로는 final 클래스를 모킹할수가 없군요..
mockito-Inline이 mockito-core를 디펜던시로 가지고 있는데요
mockito-inline dependency를 사용해서 final 클래스도 모킹할 수 있게 하는게 어떨까 싶네요
의견 부탁드릴게요~