### PR TITLE
[ Develop ] 주문시간대별 배달팁 기능

### DIFF
--- a/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/ordertimedeliverytip/DeliveryTimePeriod.java
+++ b/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/ordertimedeliverytip/DeliveryTimePeriod.java
@@ -16,6 +16,7 @@ public class DeliveryTimePeriod {
 
     private static final int HOURS_PER_DAY = 24;
     private static final int MINUTES_PER_HOUR = 60;
+    private static final LocalTime EIGHT_PM = LocalTime.of(20, 0);
 
     @Column(nullable = false)
     private LocalTime fromTime;
@@ -27,18 +28,24 @@ public class DeliveryTimePeriod {
     private Integer fromMinuteByMidnight;
 
     @Column(nullable = false)
-    private Integer toMinuteAtMidnight;
+    private Integer toMinuteByMidnight;
 
     @Builder
     private DeliveryTimePeriod(final LocalTime from, final LocalTime to) {
         this.fromTime = from;
         this.toTime = to;
-        this.fromMinuteByMidnight = convertMinuteByMidnight(from) - HOURS_PER_DAY * MINUTES_PER_HOUR;
-        this.toMinuteAtMidnight = convertMinuteByMidnight(to) - HOURS_PER_DAY * MINUTES_PER_HOUR;
+        this.fromMinuteByMidnight = isBeforeMidnight(from)
+            ? convertMinuteByMidnight(from) - HOURS_PER_DAY * MINUTES_PER_HOUR : convertMinuteByMidnight(from);
+        this.toMinuteByMidnight = isBeforeMidnight(to)
+            ? convertMinuteByMidnight(to) - HOURS_PER_DAY * MINUTES_PER_HOUR : convertMinuteByMidnight(to);
     }
 
-    private int convertMinuteByMidnight(final LocalTime time) {
+    public static int convertMinuteByMidnight(final LocalTime time) {
         return time.getHour() * MINUTES_PER_HOUR + time.getMinute();
+    }
+
+    private boolean isBeforeMidnight(final LocalTime time) {
+        return time.isAfter(EIGHT_PM) && time.isBefore(LocalTime.MIDNIGHT.minusMinutes(1));
     }
 
 }

--- a/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/ordertimedeliverytip/DeliveryTimePeriod.java
+++ b/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/ordertimedeliverytip/DeliveryTimePeriod.java
@@ -1,0 +1,44 @@
+package com.whatsub.honeybread.core.domain.ordertimedeliverytip;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import java.time.LocalTime;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DeliveryTimePeriod {
+
+    private static final int HOURS_PER_DAY = 24;
+    private static final int MINUTES_PER_HOUR = 60;
+
+    @Column(nullable = false)
+    private LocalTime fromTime;
+
+    @Column(nullable = false)
+    private LocalTime toTime;
+
+    @Column(nullable = false)
+    private Integer fromMinuteByMidnight;
+
+    @Column(nullable = false)
+    private Integer toMinuteAtMidnight;
+
+    @Builder
+    private DeliveryTimePeriod(final LocalTime from, final LocalTime to) {
+        this.fromTime = from;
+        this.toTime = to;
+        this.fromMinuteByMidnight = convertMinuteByMidnight(from) - HOURS_PER_DAY * MINUTES_PER_HOUR;
+        this.toMinuteAtMidnight = convertMinuteByMidnight(to) - HOURS_PER_DAY * MINUTES_PER_HOUR;
+    }
+
+    private int convertMinuteByMidnight(final LocalTime time) {
+        return time.getHour() * MINUTES_PER_HOUR + time.getMinute();
+    }
+
+}

--- a/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/ordertimedeliverytip/OrderTimeDeliveryTip.java
+++ b/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/ordertimedeliverytip/OrderTimeDeliveryTip.java
@@ -29,6 +29,13 @@ public class OrderTimeDeliveryTip extends BaseEntity {
     @Column(nullable = false)
     private Money tip;
 
+    public static OrderTimeDeliveryTip createZeroTip(Long storeId) {
+        return OrderTimeDeliveryTip.builder()
+            .storeId(storeId)
+            .tip(Money.ZERO)
+            .build();
+    }
+
     @Builder
     private OrderTimeDeliveryTip(final Long storeId, final DeliveryTimePeriod deliveryTimePeriod, final Money tip) {
         this.storeId = storeId;

--- a/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/ordertimedeliverytip/OrderTimeDeliveryTip.java
+++ b/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/ordertimedeliverytip/OrderTimeDeliveryTip.java
@@ -1,0 +1,39 @@
+package com.whatsub.honeybread.core.domain.ordertimedeliverytip;
+
+import com.whatsub.honeybread.core.domain.base.BaseEntity;
+import com.whatsub.honeybread.core.domain.model.Money;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+@Getter
+@EqualsAndHashCode(callSuper = true)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "order_time_delivery_tips")
+public class OrderTimeDeliveryTip extends BaseEntity {
+
+    @Column(nullable = false)
+    private Long storeId;
+
+    @Embedded
+    private DeliveryTimePeriod deliveryTimePeriod;
+
+    @Column(nullable = false)
+    private Money tip;
+
+    @Builder
+    private OrderTimeDeliveryTip(final Long storeId, final DeliveryTimePeriod deliveryTimePeriod, final Money tip) {
+        this.storeId = storeId;
+        this.deliveryTimePeriod = deliveryTimePeriod;
+        this.tip = tip;
+    }
+
+}

--- a/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/ordertimedeliverytip/OrderTimeDeliveryTipRepository.java
+++ b/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/ordertimedeliverytip/OrderTimeDeliveryTipRepository.java
@@ -2,6 +2,9 @@ package com.whatsub.honeybread.core.domain.ordertimedeliverytip;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface OrderTimeDeliveryTipRepository extends JpaRepository<OrderTimeDeliveryTip, Long> {
     boolean existsByStoreId(final long storeId);
+    Optional<OrderTimeDeliveryTip> findByStoreId(final long storeId);
 }

--- a/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/ordertimedeliverytip/OrderTimeDeliveryTipRepository.java
+++ b/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/ordertimedeliverytip/OrderTimeDeliveryTipRepository.java
@@ -1,0 +1,7 @@
+package com.whatsub.honeybread.core.domain.ordertimedeliverytip;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderTimeDeliveryTipRepository extends JpaRepository<OrderTimeDeliveryTip, Long> {
+    boolean existsByStoreId(final long storeId);
+}

--- a/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/ordertimedeliverytip/OrderTimeDeliveryTipRepository.java
+++ b/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/ordertimedeliverytip/OrderTimeDeliveryTipRepository.java
@@ -2,9 +2,11 @@ package com.whatsub.honeybread.core.domain.ordertimedeliverytip;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface OrderTimeDeliveryTipRepository extends JpaRepository<OrderTimeDeliveryTip, Long>, OrderTimeDeliveryTipRepositoryCustom {
     boolean existsByStoreId(final long storeId);
     Optional<OrderTimeDeliveryTip> findByStoreId(final long storeId);
+    List<OrderTimeDeliveryTip> findAllByStoreId(final long storeId);
 }

--- a/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/ordertimedeliverytip/OrderTimeDeliveryTipRepository.java
+++ b/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/ordertimedeliverytip/OrderTimeDeliveryTipRepository.java
@@ -8,5 +8,4 @@ import java.util.Optional;
 public interface OrderTimeDeliveryTipRepository extends JpaRepository<OrderTimeDeliveryTip, Long>, OrderTimeDeliveryTipRepositoryCustom {
     boolean existsByStoreId(final long storeId);
     Optional<OrderTimeDeliveryTip> findByStoreId(final long storeId);
-    List<OrderTimeDeliveryTip> findAllByStoreId(final long storeId);
 }

--- a/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/ordertimedeliverytip/OrderTimeDeliveryTipRepository.java
+++ b/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/ordertimedeliverytip/OrderTimeDeliveryTipRepository.java
@@ -4,7 +4,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface OrderTimeDeliveryTipRepository extends JpaRepository<OrderTimeDeliveryTip, Long> {
+public interface OrderTimeDeliveryTipRepository extends JpaRepository<OrderTimeDeliveryTip, Long>, OrderTimeDeliveryTipRepositoryCustom {
     boolean existsByStoreId(final long storeId);
     Optional<OrderTimeDeliveryTip> findByStoreId(final long storeId);
 }

--- a/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/ordertimedeliverytip/OrderTimeDeliveryTipRepositoryCustom.java
+++ b/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/ordertimedeliverytip/OrderTimeDeliveryTipRepositoryCustom.java
@@ -1,0 +1,8 @@
+package com.whatsub.honeybread.core.domain.ordertimedeliverytip;
+
+import java.time.LocalTime;
+import java.util.Optional;
+
+public interface OrderTimeDeliveryTipRepositoryCustom {
+    Optional<OrderTimeDeliveryTip> getTipByTime(final long storeId, final LocalTime time);
+}

--- a/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/ordertimedeliverytip/OrderTimeDeliveryTipRepositoryImpl.java
+++ b/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/ordertimedeliverytip/OrderTimeDeliveryTipRepositoryImpl.java
@@ -28,8 +28,11 @@ public class OrderTimeDeliveryTipRepositoryImpl extends QuerydslRepositorySuppor
 
     private Predicate includeTime(final LocalTime time) {
         final int minuteByMidnight = DeliveryTimePeriod.convertMinuteByMidnight(time);
-        return orderTimeDeliveryTip.deliveryTimePeriod.fromMinuteByMidnight.loe(minuteByMidnight)
-            .and(orderTimeDeliveryTip.deliveryTimePeriod.toMinuteByMidnight.gt(minuteByMidnight));
+        return orderTimeDeliveryTip.deliveryTimePeriod.fromMinuteByMidnight
+            .loe(minuteByMidnight)
+            .and(
+                orderTimeDeliveryTip.deliveryTimePeriod.toMinuteByMidnight.gt(minuteByMidnight)
+            );
     }
 
     private Predicate eqStoreId(final long storeId) {

--- a/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/ordertimedeliverytip/OrderTimeDeliveryTipRepositoryImpl.java
+++ b/honeybread-core/src/main/java/com/whatsub/honeybread/core/domain/ordertimedeliverytip/OrderTimeDeliveryTipRepositoryImpl.java
@@ -1,0 +1,38 @@
+package com.whatsub.honeybread.core.domain.ordertimedeliverytip;
+
+import com.querydsl.core.types.Predicate;
+import com.whatsub.honeybread.core.support.QuerydslRepositorySupport;
+
+import java.time.LocalTime;
+import java.util.Optional;
+
+import static com.whatsub.honeybread.core.domain.ordertimedeliverytip.QOrderTimeDeliveryTip.orderTimeDeliveryTip;
+
+public class OrderTimeDeliveryTipRepositoryImpl extends QuerydslRepositorySupport
+    implements OrderTimeDeliveryTipRepositoryCustom {
+
+    public OrderTimeDeliveryTipRepositoryImpl() {
+        super(OrderTimeDeliveryTip.class);
+    }
+
+    @Override
+    public Optional<OrderTimeDeliveryTip> getTipByTime(final long storeId, final LocalTime time) {
+        return Optional.ofNullable(
+            from(orderTimeDeliveryTip)
+                .where(
+                    eqStoreId(storeId),
+                    includeTime(time)
+                ).fetchOne()
+        );
+    }
+
+    private Predicate includeTime(final LocalTime time) {
+        final int minuteByMidnight = DeliveryTimePeriod.convertMinuteByMidnight(time);
+        return orderTimeDeliveryTip.deliveryTimePeriod.fromMinuteByMidnight.loe(minuteByMidnight)
+            .and(orderTimeDeliveryTip.deliveryTimePeriod.toMinuteByMidnight.gt(minuteByMidnight));
+    }
+
+    private Predicate eqStoreId(final long storeId) {
+        return orderTimeDeliveryTip.storeId.eq(storeId);
+    }
+}

--- a/honeybread-core/src/main/java/com/whatsub/honeybread/core/infra/errors/ErrorCode.java
+++ b/honeybread-core/src/main/java/com/whatsub/honeybread/core/infra/errors/ErrorCode.java
@@ -26,6 +26,8 @@ public enum ErrorCode {
     MENU_NOT_FOUND(HttpStatus.NOT_FOUND, "-30001", "Menu NotFound"),
     MENU_GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "-31001", "Menu Group NotFound"),
 
+    DUPLICATE_ORDER_TIME_DELIVERY_TIP(HttpStatus.CONFLICT, "-41000", "Duplicate Order Time Delivery Tip"),
+
     ;
     private final HttpStatus status;
     private final String code;

--- a/honeybread-core/src/main/java/com/whatsub/honeybread/core/infra/errors/ErrorCode.java
+++ b/honeybread-core/src/main/java/com/whatsub/honeybread/core/infra/errors/ErrorCode.java
@@ -27,6 +27,7 @@ public enum ErrorCode {
     MENU_GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "-31001", "Menu Group NotFound"),
 
     DUPLICATE_ORDER_TIME_DELIVERY_TIP(HttpStatus.CONFLICT, "-41000", "Duplicate Order Time Delivery Tip"),
+    ORDER_TIME_DELIVERY_TIP_NOT_FOUND(HttpStatus.NOT_FOUND, "-41001", "Order Time Delivery Tip Not Found"),
 
     ;
     private final HttpStatus status;

--- a/honeybread-core/src/test/java/com/whatsub/honeybread/core/domain/ordertimedeliverytip/DeliveryTimePeriodTest.java
+++ b/honeybread-core/src/test/java/com/whatsub/honeybread/core/domain/ordertimedeliverytip/DeliveryTimePeriodTest.java
@@ -12,17 +12,17 @@ class DeliveryTimePeriodTest {
     void 시간별_배달팁_생성시_자정_이하시간은_음수로_저장되는지_확인() {
         //given
         final DeliveryTimePeriod deliveryTimePeriod = DeliveryTimePeriod.builder()
-            .from(LocalTime.of(20, 0))
-            .to(LocalTime.of(23, 0))
+            .from(LocalTime.of(23, 0))
+            .to(LocalTime.of(5, 0))
             .build();
 
         //when
         final Integer fromMinuteAtMidnight = deliveryTimePeriod.getFromMinuteByMidnight();
-        final Integer toMinuteAtMidnight = deliveryTimePeriod.getToMinuteAtMidnight();
+        final Integer toMinuteAtMidnight = deliveryTimePeriod.getToMinuteByMidnight();
 
         //then
-        assertEquals(-240, fromMinuteAtMidnight);
-        assertEquals(-60, toMinuteAtMidnight);
+        assertEquals(-60, fromMinuteAtMidnight);
+        assertEquals(300, toMinuteAtMidnight);
     }
 
 }

--- a/honeybread-core/src/test/java/com/whatsub/honeybread/core/domain/ordertimedeliverytip/DeliveryTimePeriodTest.java
+++ b/honeybread-core/src/test/java/com/whatsub/honeybread/core/domain/ordertimedeliverytip/DeliveryTimePeriodTest.java
@@ -1,0 +1,28 @@
+package com.whatsub.honeybread.core.domain.ordertimedeliverytip;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DeliveryTimePeriodTest {
+
+    @Test
+    void 시간별_배달팁_생성시_자정_이하시간은_음수로_저장되는지_확인() {
+        //given
+        final DeliveryTimePeriod deliveryTimePeriod = DeliveryTimePeriod.builder()
+            .from(LocalTime.of(20, 0))
+            .to(LocalTime.of(23, 0))
+            .build();
+
+        //when
+        final Integer fromMinuteAtMidnight = deliveryTimePeriod.getFromMinuteByMidnight();
+        final Integer toMinuteAtMidnight = deliveryTimePeriod.getToMinuteAtMidnight();
+
+        //then
+        assertEquals(-240, fromMinuteAtMidnight);
+        assertEquals(-60, toMinuteAtMidnight);
+    }
+
+}

--- a/honeybread-core/src/test/java/com/whatsub/honeybread/core/domain/ordertimedeliverytip/OrderTimeDeliveryTipRepositoryTest.java
+++ b/honeybread-core/src/test/java/com/whatsub/honeybread/core/domain/ordertimedeliverytip/OrderTimeDeliveryTipRepositoryTest.java
@@ -63,4 +63,26 @@ class OrderTimeDeliveryTipRepositoryTest {
         assertEquals(orderTimeDeliveryTip, findTip);
     }
 
+    @Test
+    void 시간별_배달팁_storeId_time_으로_검색() {
+        //given
+        final long storeId = 1L;
+        final OrderTimeDeliveryTip orderTimeDeliveryTip = OrderTimeDeliveryTip.builder()
+            .storeId(storeId)
+            .tip(Money.wons(anyLong()))
+            .deliveryTimePeriod(DeliveryTimePeriod.builder()
+                .from(LocalTime.of(23, 0))
+                .to(LocalTime.of(8, 0))
+                .build())
+            .build();
+
+        repository.save(orderTimeDeliveryTip);
+
+        //when
+        final OrderTimeDeliveryTip findTip = repository.getTipByTime(storeId, LocalTime.of(3, 57)).get();
+
+        //then
+        assertEquals(orderTimeDeliveryTip, findTip);
+    }
+
 }

--- a/honeybread-core/src/test/java/com/whatsub/honeybread/core/domain/ordertimedeliverytip/OrderTimeDeliveryTipRepositoryTest.java
+++ b/honeybread-core/src/test/java/com/whatsub/honeybread/core/domain/ordertimedeliverytip/OrderTimeDeliveryTipRepositoryTest.java
@@ -7,10 +7,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.TestConstructor;
 
 import java.time.LocalTime;
-import java.util.List;
-import java.util.stream.IntStream;
 
-import static java.util.stream.Collectors.toList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -26,7 +23,7 @@ class OrderTimeDeliveryTipRepositoryTest {
     @Test
     void 시간별_배달팁_storeId_등록여부_체크() {
         //given
-        final OrderTimeDeliveryTip orderTimeDeliveryTip = getOrderTimeDeliveryTip();
+        final OrderTimeDeliveryTip orderTimeDeliveryTip = 시간별_배달팁_생성();
 
         repository.save(orderTimeDeliveryTip);
 
@@ -41,7 +38,7 @@ class OrderTimeDeliveryTipRepositoryTest {
     void 시간별_배달팁_storeId로_검색() {
         //given
         final long storeId = anyLong();
-        final OrderTimeDeliveryTip orderTimeDeliveryTip = getOrderTimeDeliveryTip();
+        final OrderTimeDeliveryTip orderTimeDeliveryTip = 시간별_배달팁_생성();
 
         repository.save(orderTimeDeliveryTip);
 
@@ -74,7 +71,7 @@ class OrderTimeDeliveryTipRepositoryTest {
         assertEquals(orderTimeDeliveryTip, findTip);
     }
 
-    private OrderTimeDeliveryTip getOrderTimeDeliveryTip() {
+    private OrderTimeDeliveryTip 시간별_배달팁_생성() {
         return OrderTimeDeliveryTip.builder()
             .storeId(anyLong())
             .tip(Money.wons(anyLong()))

--- a/honeybread-core/src/test/java/com/whatsub/honeybread/core/domain/ordertimedeliverytip/OrderTimeDeliveryTipRepositoryTest.java
+++ b/honeybread-core/src/test/java/com/whatsub/honeybread/core/domain/ordertimedeliverytip/OrderTimeDeliveryTipRepositoryTest.java
@@ -8,6 +8,7 @@ import org.springframework.test.context.TestConstructor;
 
 import java.time.LocalTime;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -38,6 +39,28 @@ class OrderTimeDeliveryTipRepositoryTest {
 
         //then
         assertTrue(result);
+    }
+
+    @Test
+    void 시간별_배달팁_storeId로_검색() {
+        //given
+        final long storeId = anyLong();
+        final OrderTimeDeliveryTip orderTimeDeliveryTip = OrderTimeDeliveryTip.builder()
+            .storeId(storeId)
+            .tip(Money.wons(anyLong()))
+            .deliveryTimePeriod(DeliveryTimePeriod.builder()
+                .from(LocalTime.of(anyInt(), anyInt()))
+                .to(LocalTime.of(anyInt(), anyInt()))
+                .build())
+            .build();
+
+        repository.save(orderTimeDeliveryTip);
+
+        //when
+        final OrderTimeDeliveryTip findTip = repository.findByStoreId(storeId).get();
+
+        //then
+        assertEquals(orderTimeDeliveryTip, findTip);
     }
 
 }

--- a/honeybread-core/src/test/java/com/whatsub/honeybread/core/domain/ordertimedeliverytip/OrderTimeDeliveryTipRepositoryTest.java
+++ b/honeybread-core/src/test/java/com/whatsub/honeybread/core/domain/ordertimedeliverytip/OrderTimeDeliveryTipRepositoryTest.java
@@ -7,7 +7,10 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.TestConstructor;
 
 import java.time.LocalTime;
+import java.util.List;
+import java.util.stream.IntStream;
 
+import static java.util.stream.Collectors.toList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -84,5 +87,35 @@ class OrderTimeDeliveryTipRepositoryTest {
         //then
         assertEquals(orderTimeDeliveryTip, findTip);
     }
+
+    @Test
+    void 시간별_배달팁_storeId_으로_전체검색() {
+        //given
+        final long storeId = 1L;
+        final int size = 10;
+        final List<OrderTimeDeliveryTip> orderTimeDeliveryTips = 시간별_배달팁_size만큼_생성(storeId, size);
+
+        repository.saveAll(orderTimeDeliveryTips);
+
+        //when
+        final List<OrderTimeDeliveryTip> findList = repository.findAllByStoreId(storeId);
+
+        //then
+        assertEquals(10, findList.size());
+    }
+
+    private List<OrderTimeDeliveryTip> 시간별_배달팁_size만큼_생성(final long storeId, final int size) {
+        return IntStream.range(0, size)
+            .mapToObj(i -> OrderTimeDeliveryTip.builder()
+                .storeId(storeId)
+                .tip(Money.ZERO)
+                .deliveryTimePeriod(DeliveryTimePeriod.builder()
+                    .to(LocalTime.now())
+                    .from(LocalTime.now()).build()
+                ).build())
+            .collect(toList());
+
+    }
+
 
 }

--- a/honeybread-core/src/test/java/com/whatsub/honeybread/core/domain/ordertimedeliverytip/OrderTimeDeliveryTipRepositoryTest.java
+++ b/honeybread-core/src/test/java/com/whatsub/honeybread/core/domain/ordertimedeliverytip/OrderTimeDeliveryTipRepositoryTest.java
@@ -1,0 +1,43 @@
+package com.whatsub.honeybread.core.domain.ordertimedeliverytip;
+
+import com.whatsub.honeybread.core.domain.model.Money;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.TestConstructor;
+
+import java.time.LocalTime;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@DataJpaTest
+@RequiredArgsConstructor
+class OrderTimeDeliveryTipRepositoryTest {
+
+    final OrderTimeDeliveryTipRepository repository;
+
+    @Test
+    void 시간별_배달팁_storeId_등록여부_체크() {
+        //given
+        final OrderTimeDeliveryTip orderTimeDeliveryTip = OrderTimeDeliveryTip.builder()
+            .storeId(anyLong())
+            .tip(Money.wons(anyLong()))
+            .deliveryTimePeriod(DeliveryTimePeriod.builder()
+                .from(LocalTime.of(anyInt(), anyInt()))
+                .to(LocalTime.of(anyInt(), anyInt()))
+                .build())
+            .build();
+
+        repository.save(orderTimeDeliveryTip);
+
+        //when
+        final boolean result = repository.existsByStoreId(anyLong());
+
+        //then
+        assertTrue(result);
+    }
+
+}

--- a/honeybread-core/src/test/java/com/whatsub/honeybread/core/domain/ordertimedeliverytip/OrderTimeDeliveryTipRepositoryTest.java
+++ b/honeybread-core/src/test/java/com/whatsub/honeybread/core/domain/ordertimedeliverytip/OrderTimeDeliveryTipRepositoryTest.java
@@ -88,34 +88,4 @@ class OrderTimeDeliveryTipRepositoryTest {
         assertEquals(orderTimeDeliveryTip, findTip);
     }
 
-    @Test
-    void 시간별_배달팁_storeId_으로_전체검색() {
-        //given
-        final long storeId = 1L;
-        final int size = 10;
-        final List<OrderTimeDeliveryTip> orderTimeDeliveryTips = 시간별_배달팁_size만큼_생성(storeId, size);
-
-        repository.saveAll(orderTimeDeliveryTips);
-
-        //when
-        final List<OrderTimeDeliveryTip> findList = repository.findAllByStoreId(storeId);
-
-        //then
-        assertEquals(10, findList.size());
-    }
-
-    private List<OrderTimeDeliveryTip> 시간별_배달팁_size만큼_생성(final long storeId, final int size) {
-        return IntStream.range(0, size)
-            .mapToObj(i -> OrderTimeDeliveryTip.builder()
-                .storeId(storeId)
-                .tip(Money.ZERO)
-                .deliveryTimePeriod(DeliveryTimePeriod.builder()
-                    .to(LocalTime.now())
-                    .from(LocalTime.now()).build()
-                ).build())
-            .collect(toList());
-
-    }
-
-
 }

--- a/honeybread-core/src/test/java/com/whatsub/honeybread/core/domain/ordertimedeliverytip/OrderTimeDeliveryTipRepositoryTest.java
+++ b/honeybread-core/src/test/java/com/whatsub/honeybread/core/domain/ordertimedeliverytip/OrderTimeDeliveryTipRepositoryTest.java
@@ -26,14 +26,7 @@ class OrderTimeDeliveryTipRepositoryTest {
     @Test
     void 시간별_배달팁_storeId_등록여부_체크() {
         //given
-        final OrderTimeDeliveryTip orderTimeDeliveryTip = OrderTimeDeliveryTip.builder()
-            .storeId(anyLong())
-            .tip(Money.wons(anyLong()))
-            .deliveryTimePeriod(DeliveryTimePeriod.builder()
-                .from(LocalTime.of(anyInt(), anyInt()))
-                .to(LocalTime.of(anyInt(), anyInt()))
-                .build())
-            .build();
+        final OrderTimeDeliveryTip orderTimeDeliveryTip = getOrderTimeDeliveryTip();
 
         repository.save(orderTimeDeliveryTip);
 
@@ -48,14 +41,7 @@ class OrderTimeDeliveryTipRepositoryTest {
     void 시간별_배달팁_storeId로_검색() {
         //given
         final long storeId = anyLong();
-        final OrderTimeDeliveryTip orderTimeDeliveryTip = OrderTimeDeliveryTip.builder()
-            .storeId(storeId)
-            .tip(Money.wons(anyLong()))
-            .deliveryTimePeriod(DeliveryTimePeriod.builder()
-                .from(LocalTime.of(anyInt(), anyInt()))
-                .to(LocalTime.of(anyInt(), anyInt()))
-                .build())
-            .build();
+        final OrderTimeDeliveryTip orderTimeDeliveryTip = getOrderTimeDeliveryTip();
 
         repository.save(orderTimeDeliveryTip);
 
@@ -88,4 +74,14 @@ class OrderTimeDeliveryTipRepositoryTest {
         assertEquals(orderTimeDeliveryTip, findTip);
     }
 
+    private OrderTimeDeliveryTip getOrderTimeDeliveryTip() {
+        return OrderTimeDeliveryTip.builder()
+            .storeId(anyLong())
+            .tip(Money.wons(anyLong()))
+            .deliveryTimePeriod(DeliveryTimePeriod.builder()
+                .from(LocalTime.of(anyInt(), anyInt()))
+                .to(LocalTime.of(anyInt(), anyInt()))
+                .build())
+            .build();
+    }
 }

--- a/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/domain/ordertimedeliverytip/OrderTimeDeliveryTipController.java
+++ b/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/domain/ordertimedeliverytip/OrderTimeDeliveryTipController.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -20,6 +21,7 @@ import javax.validation.Valid;
 public class OrderTimeDeliveryTipController {
 
     private final OrderTimeDeliveryTipService service;
+    private final OrderTimeDeliveryTipQueryService queryService;
 
     @PostMapping
     public ResponseEntity<Void> create(@PathVariable("storeId") long storeId,
@@ -30,6 +32,12 @@ public class OrderTimeDeliveryTipController {
         }
         service.create(storeId, request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @DeleteMapping("{id}")
+    public ResponseEntity<Void> delete(@PathVariable("id") long id) {
+        service.remove(id);
+        return ResponseEntity.noContent().build();
     }
 
 }

--- a/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/domain/ordertimedeliverytip/OrderTimeDeliveryTipController.java
+++ b/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/domain/ordertimedeliverytip/OrderTimeDeliveryTipController.java
@@ -1,0 +1,35 @@
+package com.whatsub.honeybread.mgmtadmin.domain.ordertimedeliverytip;
+
+import com.whatsub.honeybread.core.infra.exception.ValidationException;
+import com.whatsub.honeybread.mgmtadmin.domain.ordertimedeliverytip.dto.OrderTimeDeliveryTipRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("stores/{storeId}/order-time-delivery-tips")
+public class OrderTimeDeliveryTipController {
+
+    private final OrderTimeDeliveryTipService service;
+
+    @PostMapping
+    public ResponseEntity<Void> create(@PathVariable("storeId") long storeId,
+                                       @Valid @RequestBody OrderTimeDeliveryTipRequest request,
+                                       BindingResult result) {
+        if(result.hasErrors()) {
+            throw new ValidationException(result);
+        }
+        service.create(storeId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+}

--- a/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/domain/ordertimedeliverytip/OrderTimeDeliveryTipController.java
+++ b/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/domain/ordertimedeliverytip/OrderTimeDeliveryTipController.java
@@ -2,11 +2,13 @@ package com.whatsub.honeybread.mgmtadmin.domain.ordertimedeliverytip;
 
 import com.whatsub.honeybread.core.infra.exception.ValidationException;
 import com.whatsub.honeybread.mgmtadmin.domain.ordertimedeliverytip.dto.OrderTimeDeliveryTipRequest;
+import com.whatsub.honeybread.mgmtadmin.domain.ordertimedeliverytip.dto.OrderTimeDeliveryTipResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -38,6 +40,12 @@ public class OrderTimeDeliveryTipController {
     public ResponseEntity<Void> delete(@PathVariable("id") long id) {
         service.remove(id);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping
+    public ResponseEntity<OrderTimeDeliveryTipResponse> getTipByStoreId(@PathVariable("storeId") long storeId) {
+        final OrderTimeDeliveryTipResponse tipByStoreId = queryService.getTipByStoreId(storeId);
+        return ResponseEntity.ok(tipByStoreId);
     }
 
 }

--- a/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/domain/ordertimedeliverytip/OrderTimeDeliveryTipController.java
+++ b/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/domain/ordertimedeliverytip/OrderTimeDeliveryTipController.java
@@ -4,6 +4,7 @@ import com.whatsub.honeybread.core.infra.exception.ValidationException;
 import com.whatsub.honeybread.mgmtadmin.domain.ordertimedeliverytip.dto.OrderTimeDeliveryTipRequest;
 import com.whatsub.honeybread.mgmtadmin.domain.ordertimedeliverytip.dto.OrderTimeDeliveryTipResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
@@ -13,9 +14,11 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
+import java.time.LocalTime;
 
 @RestController
 @RequiredArgsConstructor
@@ -45,6 +48,14 @@ public class OrderTimeDeliveryTipController {
     @GetMapping
     public ResponseEntity<OrderTimeDeliveryTipResponse> getTipByStoreId(@PathVariable("storeId") long storeId) {
         final OrderTimeDeliveryTipResponse tipByStoreId = queryService.getTipByStoreId(storeId);
+        return ResponseEntity.ok(tipByStoreId);
+    }
+
+    @GetMapping(params = "time")
+    public ResponseEntity<OrderTimeDeliveryTipResponse> getTipByTime(
+            @PathVariable("storeId") long storeId,
+            @DateTimeFormat(pattern = "HH:mm") @RequestParam("time") LocalTime time) {
+        final OrderTimeDeliveryTipResponse tipByStoreId = queryService.getTipByTime(storeId, time);
         return ResponseEntity.ok(tipByStoreId);
     }
 

--- a/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/domain/ordertimedeliverytip/OrderTimeDeliveryTipQueryService.java
+++ b/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/domain/ordertimedeliverytip/OrderTimeDeliveryTipQueryService.java
@@ -2,6 +2,8 @@ package com.whatsub.honeybread.mgmtadmin.domain.ordertimedeliverytip;
 
 import com.whatsub.honeybread.core.domain.ordertimedeliverytip.OrderTimeDeliveryTip;
 import com.whatsub.honeybread.core.domain.ordertimedeliverytip.OrderTimeDeliveryTipRepository;
+import com.whatsub.honeybread.core.infra.errors.ErrorCode;
+import com.whatsub.honeybread.core.infra.exception.HoneyBreadException;
 import com.whatsub.honeybread.mgmtadmin.domain.ordertimedeliverytip.dto.OrderTimeDeliveryTipResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,6 +24,14 @@ public class OrderTimeDeliveryTipQueryService {
         return OrderTimeDeliveryTipResponse.of(
             repository.getTipByTime(storeId, time)
                 .orElse(OrderTimeDeliveryTip.createZeroTip(storeId))
+        );
+    }
+
+    public OrderTimeDeliveryTipResponse getTipByStoreId(final long storeId) {
+        return OrderTimeDeliveryTipResponse.of(
+            repository.findByStoreId(storeId).orElseThrow(
+                () -> new HoneyBreadException(ErrorCode.ORDER_TIME_DELIVERY_TIP_NOT_FOUND)
+            )
         );
     }
 

--- a/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/domain/ordertimedeliverytip/OrderTimeDeliveryTipQueryService.java
+++ b/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/domain/ordertimedeliverytip/OrderTimeDeliveryTipQueryService.java
@@ -8,6 +8,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
@@ -15,6 +17,12 @@ import java.time.LocalTime;
 public class OrderTimeDeliveryTipQueryService {
 
     private final OrderTimeDeliveryTipRepository repository;
+
+    public List<OrderTimeDeliveryTipResponse> getAllByStoreId(final long storeId) {
+        return repository.findAllByStoreId(storeId).stream()
+            .map(OrderTimeDeliveryTipResponse::of)
+            .collect(Collectors.toList());
+    }
 
     public OrderTimeDeliveryTipResponse getTipByTime(final long storeId, final LocalTime time) {
         return OrderTimeDeliveryTipResponse.of(

--- a/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/domain/ordertimedeliverytip/OrderTimeDeliveryTipQueryService.java
+++ b/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/domain/ordertimedeliverytip/OrderTimeDeliveryTipQueryService.java
@@ -18,12 +18,6 @@ public class OrderTimeDeliveryTipQueryService {
 
     private final OrderTimeDeliveryTipRepository repository;
 
-    public List<OrderTimeDeliveryTipResponse> getAllByStoreId(final long storeId) {
-        return repository.findAllByStoreId(storeId).stream()
-            .map(OrderTimeDeliveryTipResponse::of)
-            .collect(Collectors.toList());
-    }
-
     public OrderTimeDeliveryTipResponse getTipByTime(final long storeId, final LocalTime time) {
         return OrderTimeDeliveryTipResponse.of(
             repository.getTipByTime(storeId, time)

--- a/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/domain/ordertimedeliverytip/OrderTimeDeliveryTipQueryService.java
+++ b/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/domain/ordertimedeliverytip/OrderTimeDeliveryTipQueryService.java
@@ -1,0 +1,26 @@
+package com.whatsub.honeybread.mgmtadmin.domain.ordertimedeliverytip;
+
+import com.whatsub.honeybread.core.domain.ordertimedeliverytip.OrderTimeDeliveryTip;
+import com.whatsub.honeybread.core.domain.ordertimedeliverytip.OrderTimeDeliveryTipRepository;
+import com.whatsub.honeybread.mgmtadmin.domain.ordertimedeliverytip.dto.OrderTimeDeliveryTipResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalTime;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class OrderTimeDeliveryTipQueryService {
+
+    private final OrderTimeDeliveryTipRepository repository;
+
+    public OrderTimeDeliveryTipResponse getTipByTime(final long storeId, final LocalTime time) {
+        return OrderTimeDeliveryTipResponse.of(
+            repository.getTipByTime(storeId, time)
+                .orElse(OrderTimeDeliveryTip.createZeroTip(storeId))
+        );
+    }
+
+}

--- a/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/domain/ordertimedeliverytip/OrderTimeDeliveryTipService.java
+++ b/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/domain/ordertimedeliverytip/OrderTimeDeliveryTipService.java
@@ -24,4 +24,14 @@ public class OrderTimeDeliveryTipService {
         final OrderTimeDeliveryTip orderTimeDeliveryTip = request.toEntity(storeId);
         repository.save(orderTimeDeliveryTip);
     }
+
+    @Transactional
+    public void remove(final long storeId) {
+        repository.delete(findByStoreId(storeId));
+    }
+
+    private OrderTimeDeliveryTip findByStoreId(final long storeId) {
+        return repository.findByStoreId(storeId)
+            .orElseThrow(() -> new HoneyBreadException(ErrorCode.ORDER_TIME_DELIVERY_TIP_NOT_FOUND));
+    }
 }

--- a/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/domain/ordertimedeliverytip/OrderTimeDeliveryTipService.java
+++ b/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/domain/ordertimedeliverytip/OrderTimeDeliveryTipService.java
@@ -1,0 +1,27 @@
+package com.whatsub.honeybread.mgmtadmin.domain.ordertimedeliverytip;
+
+import com.whatsub.honeybread.core.domain.ordertimedeliverytip.OrderTimeDeliveryTip;
+import com.whatsub.honeybread.core.domain.ordertimedeliverytip.OrderTimeDeliveryTipRepository;
+import com.whatsub.honeybread.core.infra.errors.ErrorCode;
+import com.whatsub.honeybread.core.infra.exception.HoneyBreadException;
+import com.whatsub.honeybread.mgmtadmin.domain.ordertimedeliverytip.dto.OrderTimeDeliveryTipRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class OrderTimeDeliveryTipService {
+
+    private final OrderTimeDeliveryTipRepository repository;
+
+    @Transactional
+    public void create(final long storeId, final OrderTimeDeliveryTipRequest request) {
+        if(repository.existsByStoreId(storeId)) {
+            throw new HoneyBreadException(ErrorCode.DUPLICATE_ORDER_TIME_DELIVERY_TIP);
+        }
+        final OrderTimeDeliveryTip orderTimeDeliveryTip = request.toEntity(storeId);
+        repository.save(orderTimeDeliveryTip);
+    }
+}

--- a/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/domain/ordertimedeliverytip/dto/OrderTimeDeliveryTipRequest.java
+++ b/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/domain/ordertimedeliverytip/dto/OrderTimeDeliveryTipRequest.java
@@ -1,0 +1,28 @@
+package com.whatsub.honeybread.mgmtadmin.domain.ordertimedeliverytip.dto;
+
+import com.whatsub.honeybread.core.domain.model.Money;
+import com.whatsub.honeybread.core.domain.ordertimedeliverytip.DeliveryTimePeriod;
+import com.whatsub.honeybread.core.domain.ordertimedeliverytip.OrderTimeDeliveryTip;
+import lombok.Value;
+
+import java.time.LocalTime;
+
+@Value
+public class OrderTimeDeliveryTipRequest {
+
+    LocalTime from;
+    LocalTime to;
+    Money tip;
+
+    public OrderTimeDeliveryTip toEntity(long storeId) {
+        return OrderTimeDeliveryTip.builder()
+            .storeId(storeId)
+            .tip(tip)
+            .deliveryTimePeriod(DeliveryTimePeriod.builder()
+                .to(to)
+                .from(from)
+                .build())
+            .build();
+    }
+
+}

--- a/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/domain/ordertimedeliverytip/dto/OrderTimeDeliveryTipRequest.java
+++ b/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/domain/ordertimedeliverytip/dto/OrderTimeDeliveryTipRequest.java
@@ -5,24 +5,30 @@ import com.whatsub.honeybread.core.domain.ordertimedeliverytip.DeliveryTimePerio
 import com.whatsub.honeybread.core.domain.ordertimedeliverytip.OrderTimeDeliveryTip;
 import lombok.Value;
 
+import javax.validation.constraints.NotNull;
 import java.time.LocalTime;
 
 @Value
 public class OrderTimeDeliveryTipRequest {
 
+    @NotNull
     LocalTime from;
+
+    @NotNull
     LocalTime to;
+
+    @NotNull
     Money tip;
 
-    public OrderTimeDeliveryTip toEntity(long storeId) {
+    public OrderTimeDeliveryTip toEntity(final long storeId) {
         return OrderTimeDeliveryTip.builder()
             .storeId(storeId)
             .tip(tip)
             .deliveryTimePeriod(DeliveryTimePeriod.builder()
                 .to(to)
                 .from(from)
-                .build())
-            .build();
+                .build()
+            ).build();
     }
 
 }

--- a/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/domain/ordertimedeliverytip/dto/OrderTimeDeliveryTipResponse.java
+++ b/honeybread-mgmtadmin/src/main/java/com/whatsub/honeybread/mgmtadmin/domain/ordertimedeliverytip/dto/OrderTimeDeliveryTipResponse.java
@@ -1,0 +1,22 @@
+package com.whatsub.honeybread.mgmtadmin.domain.ordertimedeliverytip.dto;
+
+import com.whatsub.honeybread.core.domain.model.Money;
+import com.whatsub.honeybread.core.domain.ordertimedeliverytip.DeliveryTimePeriod;
+import com.whatsub.honeybread.core.domain.ordertimedeliverytip.OrderTimeDeliveryTip;
+import lombok.Value;
+
+@Value
+public class OrderTimeDeliveryTipResponse {
+
+    Long storeId;
+    DeliveryTimePeriod deliveryTimePeriod;
+    Money tip;
+
+    public static OrderTimeDeliveryTipResponse of(final OrderTimeDeliveryTip orderTimeDeliveryTip) {
+        return new OrderTimeDeliveryTipResponse(orderTimeDeliveryTip.getStoreId(),
+            orderTimeDeliveryTip.getDeliveryTimePeriod(),
+            orderTimeDeliveryTip.getTip()
+        );
+    }
+
+}

--- a/honeybread-mgmtadmin/src/test/java/com/whatsub/honeybread/mgmtadmin/domain/ordertimedeliverytip/OrderTimeDeliveryTipControllerTest.java
+++ b/honeybread-mgmtadmin/src/test/java/com/whatsub/honeybread/mgmtadmin/domain/ordertimedeliverytip/OrderTimeDeliveryTipControllerTest.java
@@ -127,14 +127,9 @@ class OrderTimeDeliveryTipControllerTest {
         결과응답이_예상과_같아야함(HttpStatus.OK, resultActions);
     }
 
-    private ResultActions 시간별_배달팁_StoreId_Time_조회_요청() throws Exception {
-        final LocalTime time = LocalTime.of(anyInt(), anyInt());
-        return mockMvc.perform(get(BASE_URL)
-            .contentType(MediaType.APPLICATION_JSON)
-            .accept(MediaType.APPLICATION_JSON)
-            .param("time", time.toString())
-        ).andDo(print());
-    }
+    /**
+     * given
+     */
 
     private void 시간별_배달팁이_StoreId_Time으로_조회_성공() {
         given(queryService.getTipByTime(anyLong(), any(LocalTime.class)))
@@ -147,35 +142,27 @@ class OrderTimeDeliveryTipControllerTest {
             .willThrow(new HoneyBreadException(ErrorCode.ORDER_TIME_DELIVERY_TIP_NOT_FOUND));
     }
 
-    private void 시간별_배달팁_조회_검증(final ResultActions resultActions) throws Exception {
-        resultActions.andExpect(jsonPath("$").exists());
-    }
-
     private void 시간별_배달팁이_StoreId로_조회_성공() {
         given(queryService.getTipByStoreId(anyLong()))
             .willReturn(mock(OrderTimeDeliveryTipResponse.class));
     }
 
-    private ResultActions 시간별_배달팁_StoreId_조회_요청() throws Exception {
-        return mockMvc.perform(get(BASE_URL)
-            .contentType(MediaType.APPLICATION_JSON)
-            .accept(MediaType.APPLICATION_JSON)
-        ).andDo(print());
-    }
-
-    private void 시간별_배달팁이_삭제되어야함() {
-        then(service).should().remove(anyLong());
-    }
-
-    private ResultActions 시간별_배달팁_삭제_요청(final long id) throws Exception {
-        return mockMvc.perform(delete(BASE_URL + "/" + id)
-            .contentType(MediaType.APPLICATION_JSON)
-            .accept(MediaType.APPLICATION_JSON)
-        ).andDo(print());
-    }
-
     private OrderTimeDeliveryTipRequest 시간별_배달팁_생성_실패_요청() {
         return new OrderTimeDeliveryTipRequest(null, null, null);
+    }
+
+    private OrderTimeDeliveryTipRequest 시간별_배달팁_생성_요청() {
+        return new OrderTimeDeliveryTipRequest(LocalTime.of(23, 0),
+            LocalTime.of(23, 0),
+            Money.wons(1000));
+    }
+
+    /**
+     * then
+     */
+
+    public void 결과응답이_예상과_같아야함(final HttpStatus expect, final ResultActions resultActions) throws Exception {
+        resultActions.andExpect(status().is(expect.value()));
     }
 
     private void 시간별_배달팁이_생성되지_않아야함() {
@@ -186,6 +173,18 @@ class OrderTimeDeliveryTipControllerTest {
         then(service).should().create(anyLong(), any(OrderTimeDeliveryTipRequest.class));
     }
 
+    private void 시간별_배달팁_조회_검증(final ResultActions resultActions) throws Exception {
+        resultActions.andExpect(jsonPath("$").exists());
+    }
+
+    private void 시간별_배달팁이_삭제되어야함() {
+        then(service).should().remove(anyLong());
+    }
+
+    /**
+     * request
+     */
+
     private ResultActions 시간별_배달팁_생성_요청(final OrderTimeDeliveryTipRequest request) throws Exception {
         return mockMvc.perform(post(BASE_URL)
             .contentType(MediaType.APPLICATION_JSON)
@@ -194,15 +193,26 @@ class OrderTimeDeliveryTipControllerTest {
         ).andDo(print());
     }
 
-    private OrderTimeDeliveryTipRequest 시간별_배달팁_생성_요청() {
-        return new OrderTimeDeliveryTipRequest(LocalTime.of(23, 0),
-            LocalTime.of(23, 0),
-            Money.wons(1000));
+    private ResultActions 시간별_배달팁_삭제_요청(final long id) throws Exception {
+        return mockMvc.perform(delete(BASE_URL + "/" + id)
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON)
+        ).andDo(print());
     }
 
-    public void 결과응답이_예상과_같아야함(final HttpStatus expect, final ResultActions resultActions) throws Exception {
-        resultActions.andExpect(status().is(expect.value()));
+    private ResultActions 시간별_배달팁_StoreId_조회_요청() throws Exception {
+        return mockMvc.perform(get(BASE_URL)
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON)
+        ).andDo(print());
     }
 
-
+    private ResultActions 시간별_배달팁_StoreId_Time_조회_요청() throws Exception {
+        final LocalTime time = LocalTime.of(anyInt(), anyInt());
+        return mockMvc.perform(get(BASE_URL)
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON)
+            .param("time", time.toString())
+        ).andDo(print());
+    }
 }

--- a/honeybread-mgmtadmin/src/test/java/com/whatsub/honeybread/mgmtadmin/domain/ordertimedeliverytip/OrderTimeDeliveryTipControllerTest.java
+++ b/honeybread-mgmtadmin/src/test/java/com/whatsub/honeybread/mgmtadmin/domain/ordertimedeliverytip/OrderTimeDeliveryTipControllerTest.java
@@ -1,0 +1,97 @@
+package com.whatsub.honeybread.mgmtadmin.domain.ordertimedeliverytip;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.whatsub.honeybread.core.domain.model.Money;
+import com.whatsub.honeybread.mgmtadmin.domain.ordertimedeliverytip.dto.OrderTimeDeliveryTipRequest;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestConstructor;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.time.LocalTime;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@RequiredArgsConstructor
+@WebMvcTest(controllers = OrderTimeDeliveryTipController.class)
+class OrderTimeDeliveryTipControllerTest {
+
+    static final String BASE_URL = "/stores/1/order-time-delivery-tips";
+
+    final MockMvc mockMvc;
+
+    final ObjectMapper objectMapper;
+
+    @MockBean
+    OrderTimeDeliveryTipService service;
+
+    @Test
+    void 시간별_배달팁_생성() throws Exception {
+        //given
+        final OrderTimeDeliveryTipRequest request = 시간별_배달팁_생성_요청();
+
+        //when
+        final ResultActions resultActions = 시간별_배달팁_생성_요청(request);
+
+        //then
+        결과응답이_예상과_같아야함(HttpStatus.CREATED, resultActions);
+        시간별_배달팁이_생성되어야함();
+    }
+
+    @Test
+    void 시간별_배달팁_생성시_유효성검사_실패() throws Exception {
+        //given
+        final OrderTimeDeliveryTipRequest request = 시간별_배달팁_생성_실패_요청();
+
+        //when
+        final ResultActions resultActions = 시간별_배달팁_생성_요청(request);
+
+        //then
+        결과응답이_예상과_같아야함(HttpStatus.BAD_REQUEST, resultActions);
+        시간별_배달팁이_생성되지_않아야함();
+    }
+
+    private OrderTimeDeliveryTipRequest 시간별_배달팁_생성_실패_요청() {
+        return new OrderTimeDeliveryTipRequest(null, null, null);
+    }
+
+    private void 시간별_배달팁이_생성되지_않아야함() {
+        then(service).should(never()).create(anyLong(), any(OrderTimeDeliveryTipRequest.class));
+    }
+
+    private void 시간별_배달팁이_생성되어야함() {
+        then(service).should().create(anyLong(), any(OrderTimeDeliveryTipRequest.class));
+    }
+
+    private ResultActions 시간별_배달팁_생성_요청(final OrderTimeDeliveryTipRequest request) throws Exception {
+        return mockMvc.perform(post(BASE_URL)
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(request))
+        ).andDo(print());
+    }
+
+    private OrderTimeDeliveryTipRequest 시간별_배달팁_생성_요청() {
+        return new OrderTimeDeliveryTipRequest(LocalTime.of(23, 0),
+            LocalTime.of(23, 0),
+            Money.wons(1000));
+    }
+
+    public void 결과응답이_예상과_같아야함(final HttpStatus expect, final ResultActions resultActions) throws Exception {
+        resultActions.andExpect(status().is(expect.value()));
+    }
+
+
+}

--- a/honeybread-mgmtadmin/src/test/java/com/whatsub/honeybread/mgmtadmin/domain/ordertimedeliverytip/OrderTimeDeliveryTipControllerTest.java
+++ b/honeybread-mgmtadmin/src/test/java/com/whatsub/honeybread/mgmtadmin/domain/ordertimedeliverytip/OrderTimeDeliveryTipControllerTest.java
@@ -19,6 +19,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -61,6 +62,30 @@ class OrderTimeDeliveryTipControllerTest {
         //then
         결과응답이_예상과_같아야함(HttpStatus.BAD_REQUEST, resultActions);
         시간별_배달팁이_생성되지_않아야함();
+    }
+
+    @Test
+    void 시간별_배달팁_삭제() throws Exception {
+        //given
+        final long id = 1;
+
+        //when
+        final ResultActions resultActions = 시간별_배달팁_삭제_요청(id);
+
+        //then
+        결과응답이_예상과_같아야함(HttpStatus.NO_CONTENT, resultActions);
+        시간별_배달팁이_삭제되어야함();
+    }
+
+    private void 시간별_배달팁이_삭제되어야함() {
+        then(service).should().remove(anyLong());
+    }
+
+    private ResultActions 시간별_배달팁_삭제_요청(final long id) throws Exception {
+        return mockMvc.perform(delete(BASE_URL + "/" + id)
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON)
+        ).andDo(print());
     }
 
     private OrderTimeDeliveryTipRequest 시간별_배달팁_생성_실패_요청() {

--- a/honeybread-mgmtadmin/src/test/java/com/whatsub/honeybread/mgmtadmin/domain/ordertimedeliverytip/OrderTimeDeliveryTipControllerTest.java
+++ b/honeybread-mgmtadmin/src/test/java/com/whatsub/honeybread/mgmtadmin/domain/ordertimedeliverytip/OrderTimeDeliveryTipControllerTest.java
@@ -136,7 +136,6 @@ class OrderTimeDeliveryTipControllerTest {
             .willReturn(mock(OrderTimeDeliveryTipResponse.class));
     }
 
-
     private void 시간별_배달팁이_StoreId로_조회_실패() {
         given(queryService.getTipByStoreId(anyLong()))
             .willThrow(new HoneyBreadException(ErrorCode.ORDER_TIME_DELIVERY_TIP_NOT_FOUND));

--- a/honeybread-mgmtadmin/src/test/java/com/whatsub/honeybread/mgmtadmin/domain/ordertimedeliverytip/OrderTimeDeliveryTipControllerTest.java
+++ b/honeybread-mgmtadmin/src/test/java/com/whatsub/honeybread/mgmtadmin/domain/ordertimedeliverytip/OrderTimeDeliveryTipControllerTest.java
@@ -19,6 +19,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import java.time.LocalTime;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -112,6 +113,34 @@ class OrderTimeDeliveryTipControllerTest {
         //then
         결과응답이_예상과_같아야함(HttpStatus.NOT_FOUND, resultActions);
     }
+
+    @Test
+    void 시간별_배달팁_StoreId_Time_조회() throws Exception {
+        //given
+        시간별_배달팁이_StoreId_Time으로_조회_성공();
+
+        //when
+        final ResultActions resultActions = 시간별_배달팁_StoreId_Time_조회_요청();
+
+        //then
+        시간별_배달팁_조회_검증(resultActions);
+        결과응답이_예상과_같아야함(HttpStatus.OK, resultActions);
+    }
+
+    private ResultActions 시간별_배달팁_StoreId_Time_조회_요청() throws Exception {
+        final LocalTime time = LocalTime.of(anyInt(), anyInt());
+        return mockMvc.perform(get(BASE_URL)
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON)
+            .param("time", time.toString())
+        ).andDo(print());
+    }
+
+    private void 시간별_배달팁이_StoreId_Time으로_조회_성공() {
+        given(queryService.getTipByTime(anyLong(), any(LocalTime.class)))
+            .willReturn(mock(OrderTimeDeliveryTipResponse.class));
+    }
+
 
     private void 시간별_배달팁이_StoreId로_조회_실패() {
         given(queryService.getTipByStoreId(anyLong()))

--- a/honeybread-mgmtadmin/src/test/java/com/whatsub/honeybread/mgmtadmin/domain/ordertimedeliverytip/OrderTimeDeliveryTipQueryServiceTest.java
+++ b/honeybread-mgmtadmin/src/test/java/com/whatsub/honeybread/mgmtadmin/domain/ordertimedeliverytip/OrderTimeDeliveryTipQueryServiceTest.java
@@ -106,6 +106,7 @@ class OrderTimeDeliveryTipQueryServiceTest {
     /**
      * then
      */
+
     private void 반환된_에러가_예상과_같은지확인(final ErrorCode duplicateOrderPriceDeliveryTip,
                                    final HoneyBreadException actual) {
         assertEquals(duplicateOrderPriceDeliveryTip, actual.getErrorCode());

--- a/honeybread-mgmtadmin/src/test/java/com/whatsub/honeybread/mgmtadmin/domain/ordertimedeliverytip/OrderTimeDeliveryTipQueryServiceTest.java
+++ b/honeybread-mgmtadmin/src/test/java/com/whatsub/honeybread/mgmtadmin/domain/ordertimedeliverytip/OrderTimeDeliveryTipQueryServiceTest.java
@@ -10,12 +10,16 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.TestConstructor;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 @SpringBootTest(classes = OrderTimeDeliveryTipQueryService.class)
 @TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
@@ -50,6 +54,29 @@ class OrderTimeDeliveryTipQueryServiceTest {
 
         //then
         assertEquals(0, response.getTip().getValue().intValue());
+    }
+
+    @Test
+    void 시간별_배달팁_전체_검색() {
+        //given
+        final int size = 10;
+        시간별_배달팁_리스트_사이즈만큼_생성(size);
+
+        //when
+        final List<OrderTimeDeliveryTipResponse> responses = queryService.getAllByStoreId(anyLong());
+
+        //then
+        assertEquals(10, responses.size());
+    }
+
+    /**
+     * given
+     */
+    private void 시간별_배달팁_리스트_사이즈만큼_생성(final int size) {
+        final List<OrderTimeDeliveryTip> list = IntStream.range(0, size)
+            .mapToObj(ignore -> mock(OrderTimeDeliveryTip.class))
+            .collect(Collectors.toList());
+        given(repository.findAllByStoreId(anyLong())).willReturn(list);
     }
 
     private void 시간별_배달팁_검색_결과_없음() {

--- a/honeybread-mgmtadmin/src/test/java/com/whatsub/honeybread/mgmtadmin/domain/ordertimedeliverytip/OrderTimeDeliveryTipQueryServiceTest.java
+++ b/honeybread-mgmtadmin/src/test/java/com/whatsub/honeybread/mgmtadmin/domain/ordertimedeliverytip/OrderTimeDeliveryTipQueryServiceTest.java
@@ -1,0 +1,67 @@
+package com.whatsub.honeybread.mgmtadmin.domain.ordertimedeliverytip;
+
+import com.whatsub.honeybread.core.domain.model.Money;
+import com.whatsub.honeybread.core.domain.ordertimedeliverytip.OrderTimeDeliveryTip;
+import com.whatsub.honeybread.core.domain.ordertimedeliverytip.OrderTimeDeliveryTipRepository;
+import com.whatsub.honeybread.mgmtadmin.domain.ordertimedeliverytip.dto.OrderTimeDeliveryTipResponse;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.TestConstructor;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+
+@SpringBootTest(classes = OrderTimeDeliveryTipQueryService.class)
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@RequiredArgsConstructor
+class OrderTimeDeliveryTipQueryServiceTest {
+
+    final OrderTimeDeliveryTipQueryService queryService;
+
+    @MockBean
+    OrderTimeDeliveryTipRepository repository;
+
+    @Test
+    void 시간별_배달팁_검색() {
+        //given
+        int price = 1000;
+        시간별_배달팁_검색_성공(price);
+
+        //when
+        final OrderTimeDeliveryTipResponse response = queryService.getTipByTime(anyLong(), any());
+
+        //then
+        assertEquals(price, response.getTip().getValue().intValue());
+    }
+
+    @Test
+    void 시간별_배달팁_검색시_추가금_없음() {
+        //given
+        시간별_배달팁_검색_결과_없음();
+
+        //when
+        final OrderTimeDeliveryTipResponse response = queryService.getTipByTime(anyLong(), any());
+
+        //then
+        assertEquals(0, response.getTip().getValue().intValue());
+    }
+
+    private void 시간별_배달팁_검색_결과_없음() {
+        given(repository.getTipByTime(anyLong(), any()))
+            .willReturn(Optional.empty());
+    }
+
+    private void 시간별_배달팁_검색_성공(final int price) {
+        final OrderTimeDeliveryTip tip = OrderTimeDeliveryTip.builder()
+            .tip(Money.wons(price))
+            .build();
+        given(repository.getTipByTime(anyLong(), any()))
+            .willReturn(Optional.of(tip));
+    }
+}

--- a/honeybread-mgmtadmin/src/test/java/com/whatsub/honeybread/mgmtadmin/domain/ordertimedeliverytip/OrderTimeDeliveryTipQueryServiceTest.java
+++ b/honeybread-mgmtadmin/src/test/java/com/whatsub/honeybread/mgmtadmin/domain/ordertimedeliverytip/OrderTimeDeliveryTipQueryServiceTest.java
@@ -56,28 +56,9 @@ class OrderTimeDeliveryTipQueryServiceTest {
         assertEquals(0, response.getTip().getValue().intValue());
     }
 
-    @Test
-    void 시간별_배달팁_전체_검색() {
-        //given
-        final int size = 10;
-        시간별_배달팁_리스트_사이즈만큼_생성(size);
-
-        //when
-        final List<OrderTimeDeliveryTipResponse> responses = queryService.getAllByStoreId(anyLong());
-
-        //then
-        assertEquals(10, responses.size());
-    }
-
     /**
      * given
      */
-    private void 시간별_배달팁_리스트_사이즈만큼_생성(final int size) {
-        final List<OrderTimeDeliveryTip> list = IntStream.range(0, size)
-            .mapToObj(ignore -> mock(OrderTimeDeliveryTip.class))
-            .collect(Collectors.toList());
-        given(repository.findAllByStoreId(anyLong())).willReturn(list);
-    }
 
     private void 시간별_배달팁_검색_결과_없음() {
         given(repository.getTipByTime(anyLong(), any()))

--- a/honeybread-mgmtadmin/src/test/java/com/whatsub/honeybread/mgmtadmin/domain/ordertimedeliverytip/OrderTimeDeliveryTipServiceTest.java
+++ b/honeybread-mgmtadmin/src/test/java/com/whatsub/honeybread/mgmtadmin/domain/ordertimedeliverytip/OrderTimeDeliveryTipServiceTest.java
@@ -101,13 +101,30 @@ class OrderTimeDeliveryTipServiceTest {
         반환된_에러가_예상과_같은지확인(ErrorCode.ORDER_TIME_DELIVERY_TIP_NOT_FOUND, actual);
     }
 
-    private void 시간별_배달팁이_삭제되지_않아야함() {
-        then(repository).should(never()).delete(any(OrderTimeDeliveryTip.class));
-    }
+    /**
+     * given
+     */
 
     private void 시간별_배달팁이_storeId로_검색() {
         given(repository.findByStoreId(anyLong()))
             .willReturn(Optional.of(mock(OrderTimeDeliveryTip.class)));
+    }
+
+    private void 시간별_배달팁이_중복됨() {
+        given(repository.existsByStoreId(anyLong()))
+            .willReturn(true);
+    }
+
+    private OrderTimeDeliveryTipRequest 시간별_배달팁_요청_생성(final LocalTime from, final LocalTime to, final int price) {
+        return new OrderTimeDeliveryTipRequest(from, to, Money.wons(price));
+    }
+
+    /**
+     * then
+     */
+
+    private void 시간별_배달팁이_삭제되지_않아야함() {
+        then(repository).should(never()).delete(any(OrderTimeDeliveryTip.class));
     }
 
     private void 시간별_배달팁이_storeId로_검색되어야함() {
@@ -127,21 +144,12 @@ class OrderTimeDeliveryTipServiceTest {
         then(repository).should(never()).save(any(OrderTimeDeliveryTip.class));
     }
 
-    private void 시간별_배달팁이_중복됨() {
-        given(repository.existsByStoreId(anyLong()))
-            .willReturn(true);
-    }
-
     private void 시간별_배달팁_중복체크가_되어야함() {
         then(repository).should().existsByStoreId(anyLong());
     }
 
     private void 시간별_배달팁이_생성되어야함() {
         then(repository).should().save(any(OrderTimeDeliveryTip.class));
-    }
-
-    private OrderTimeDeliveryTipRequest 시간별_배달팁_요청_생성(final LocalTime from, final LocalTime to, final int price) {
-        return new OrderTimeDeliveryTipRequest(from, to, Money.wons(price));
     }
 
 }

--- a/honeybread-mgmtadmin/src/test/java/com/whatsub/honeybread/mgmtadmin/domain/ordertimedeliverytip/OrderTimeDeliveryTipServiceTest.java
+++ b/honeybread-mgmtadmin/src/test/java/com/whatsub/honeybread/mgmtadmin/domain/ordertimedeliverytip/OrderTimeDeliveryTipServiceTest.java
@@ -1,0 +1,99 @@
+package com.whatsub.honeybread.mgmtadmin.domain.ordertimedeliverytip;
+
+import com.whatsub.honeybread.core.domain.model.Money;
+import com.whatsub.honeybread.core.domain.ordertimedeliverytip.OrderTimeDeliveryTip;
+import com.whatsub.honeybread.core.domain.ordertimedeliverytip.OrderTimeDeliveryTipRepository;
+import com.whatsub.honeybread.core.infra.errors.ErrorCode;
+import com.whatsub.honeybread.core.infra.exception.HoneyBreadException;
+import com.whatsub.honeybread.mgmtadmin.domain.ordertimedeliverytip.dto.OrderTimeDeliveryTipRequest;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.TestConstructor;
+
+import java.time.LocalTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@RequiredArgsConstructor
+@SpringBootTest(classes = OrderTimeDeliveryTipService.class)
+class OrderTimeDeliveryTipServiceTest {
+
+    final OrderTimeDeliveryTipService service;
+
+    @MockBean
+    OrderTimeDeliveryTipRepository repository;
+
+    @Test
+    void 시간별_배달팁_생성() {
+        //given
+        final long storeId = 1L;
+        final OrderTimeDeliveryTipRequest request =
+            시간별_배달팁_요청_생성(LocalTime.of(23,00)
+                , LocalTime.of( 5, 0)
+                , 1000);
+
+        //when
+        service.create(storeId, request);
+
+        //then
+        시간별_배달팁이_생성되어야함();
+        시간별_배달팁_중복체크가_되어야함();
+    }
+
+    @Test
+    void 시간별_배달팁_생성시_storeId_중복_생성_실패() {
+        //given
+        final long storeId = 1L;
+        final OrderTimeDeliveryTipRequest request =
+            시간별_배달팁_요청_생성(LocalTime.of(23,00)
+                , LocalTime.of( 5, 0)
+                , 1000);
+
+        시간별_배달팁이_중복됨();
+
+       //when
+        final HoneyBreadException actual
+            = assertThrows(HoneyBreadException.class, () -> service.create(storeId, request));
+
+        //then
+        시간별_배달팁이_생성되지_않아야함();
+        시간별_배달팁_중복체크가_되어야함();
+        반환된_에러가_예상과_같은지확인(ErrorCode.DUPLICATE_ORDER_TIME_DELIVERY_TIP, actual);
+    }
+
+    private void 반환된_에러가_예상과_같은지확인(final ErrorCode duplicateOrderPriceDeliveryTip,
+                                   final HoneyBreadException actual) {
+        assertEquals(duplicateOrderPriceDeliveryTip, actual.getErrorCode());
+    }
+
+    private void 시간별_배달팁이_생성되지_않아야함() {
+        then(repository).should(never()).save(any(OrderTimeDeliveryTip.class));
+    }
+
+    private void 시간별_배달팁이_중복됨() {
+        given(repository.existsByStoreId(anyLong()))
+            .willReturn(true);
+    }
+
+    private void 시간별_배달팁_중복체크가_되어야함() {
+        then(repository).should().existsByStoreId(anyLong());
+    }
+
+    private void 시간별_배달팁이_생성되어야함() {
+        then(repository).should().save(any(OrderTimeDeliveryTip.class));
+    }
+
+    private OrderTimeDeliveryTipRequest 시간별_배달팁_요청_생성(final LocalTime from, final LocalTime to, final int price) {
+        return new OrderTimeDeliveryTipRequest(from, to, Money.wons(price));
+    }
+
+}

--- a/honeybread-mgmtadmin/src/test/java/com/whatsub/honeybread/mgmtadmin/domain/ordertimedeliverytip/OrderTimeDeliveryTipServiceTest.java
+++ b/honeybread-mgmtadmin/src/test/java/com/whatsub/honeybread/mgmtadmin/domain/ordertimedeliverytip/OrderTimeDeliveryTipServiceTest.java
@@ -13,6 +13,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.TestConstructor;
 
 import java.time.LocalTime;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -20,6 +21,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 
 @TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
@@ -60,7 +62,7 @@ class OrderTimeDeliveryTipServiceTest {
 
         시간별_배달팁이_중복됨();
 
-       //when
+        //when
         final HoneyBreadException actual
             = assertThrows(HoneyBreadException.class, () -> service.create(storeId, request));
 
@@ -68,6 +70,52 @@ class OrderTimeDeliveryTipServiceTest {
         시간별_배달팁이_생성되지_않아야함();
         시간별_배달팁_중복체크가_되어야함();
         반환된_에러가_예상과_같은지확인(ErrorCode.DUPLICATE_ORDER_TIME_DELIVERY_TIP, actual);
+    }
+
+    @Test
+    void 시간별_배달팁_삭제() {
+        //given
+        final long storeId = 1L;
+        시간별_배달팁이_storeId로_검색();
+
+        //when
+        service.remove(storeId);
+
+        //then
+        시간별_배달팁이_삭제되어야함();
+        시간별_배달팁이_storeId로_검색되어야함();
+    }
+
+    @Test
+    void 시간별_배달팁_삭제_실패() {
+        //given
+        final long storeId = 1L;
+
+        //when
+        final HoneyBreadException actual
+            = assertThrows(HoneyBreadException.class, () -> service.remove(storeId));
+
+        //then
+        시간별_배달팁이_삭제되지_않아야함();
+        시간별_배달팁이_storeId로_검색되어야함();
+        반환된_에러가_예상과_같은지확인(ErrorCode.ORDER_TIME_DELIVERY_TIP_NOT_FOUND, actual);
+    }
+
+    private void 시간별_배달팁이_삭제되지_않아야함() {
+        then(repository).should(never()).delete(any(OrderTimeDeliveryTip.class));
+    }
+
+    private void 시간별_배달팁이_storeId로_검색() {
+        given(repository.findByStoreId(anyLong()))
+            .willReturn(Optional.of(mock(OrderTimeDeliveryTip.class)));
+    }
+
+    private void 시간별_배달팁이_storeId로_검색되어야함() {
+        then(repository).should().findByStoreId(anyLong());
+    }
+
+    private void 시간별_배달팁이_삭제되어야함() {
+        then(repository).should().delete(any(OrderTimeDeliveryTip.class));
     }
 
     private void 반환된_에러가_예상과_같은지확인(final ErrorCode duplicateOrderPriceDeliveryTip,


### PR DESCRIPTION
주문시간대별로 배달팁을 추가할 수 있는 기능입니다~

![image](https://user-images.githubusercontent.com/30790184/119076804-2eb7ee00-ba2e-11eb-8e3a-aa18f1aa3baf.png)
  
![image](https://user-images.githubusercontent.com/30790184/119077385-26ac7e00-ba2f-11eb-8cee-9399cca1f000.png)

일단 위 이미지에서 요일개념, 하루종일 기능은 추가하지 않았구요..

실제 위 이미지처럼 시간대 선택이 몇시부터 몇시까지 가능한지를 몰라서 일단 20:00 ~ 9:00 까지 설정 가능하게 하려 합니다~

시간대 선택 (20:00 ~ 9:00) <- 이 기능은 추가로 Validation 레이어 구성해서 주말 내로 작업 예정입니다 참고하고 봐주세요~!


* 시간대별로 배달팁을 검색하는 부분은 자정시간을 기준으로 분으로 환산해서 +,-로 구성을 했어요~ 예를 들어 23:00 ~ 5:00 까지 지정한 상태라면 -60, 300 을 별도의 integer 컬럼에 구성해서 검색하려는 시간(ex 3:00 -> 180)을 쿼리에서 바로 검색 가능하도록 개발한 부분 참고해주시면 될 것 같습니다~~!